### PR TITLE
fix: return signed event id for encrypted message correlation

### DIFF
--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -101,7 +101,8 @@ impl BaseTransport {
 
     /// Send an MCP message to a recipient, optionally encrypting.
     ///
-    /// Returns the event ID of the published event.
+    /// Returns the signed MCP event ID.
+    /// When encrypted, this is the inner signed event ID.
     pub async fn send_mcp_message(
         &self,
         message: &JsonRpcMessage,
@@ -113,6 +114,7 @@ impl BaseTransport {
         let should_encrypt = self.should_encrypt(kind, is_encrypted);
 
         let event = self.create_signed_event(message, kind, tags).await?;
+        let signed_event_id = event.id;
 
         if should_encrypt {
             // Single-layer gift wrap: JSON.stringify(signedEvent) → NIP-44 encrypt
@@ -124,14 +126,18 @@ impl BaseTransport {
             let gift_wrap_event = encryption::gift_wrap_single_layer(
                 &signer, recipient, &event_json,
             ).await?;
-            let event_id = self.relay_pool.publish_event(&gift_wrap_event).await?;
-            tracing::debug!(event_id = %event_id, "Sent encrypted MCP message");
-            Ok(event_id)
+            self.relay_pool.publish_event(&gift_wrap_event).await?;
+            tracing::debug!(
+                signed_event_id = %signed_event_id,
+                envelope_id = %gift_wrap_event.id,
+                "Sent encrypted MCP message"
+            );
         } else {
-            let event_id = self.relay_pool.publish_event(&event).await?;
-            tracing::debug!(event_id = %event_id, "Sent unencrypted MCP message");
-            Ok(event_id)
+            self.relay_pool.publish_event(&event).await?;
+            tracing::debug!(signed_event_id = %signed_event_id, "Sent unencrypted MCP message");
         }
+
+        Ok(signed_event_id)
     }
 
     /// Determine whether a message should be encrypted.


### PR DESCRIPTION
### Before

Running gateway:
```
    Running `target/debug/examples/gateway`
Server pubkey: 6921d969fc2837a639f771b7b005f90c21ab4a847f54c414cd1316d3ed6665c1
2026-04-03T06:30:10.137778Z  INFO contextvm_sdk::transport::server: Server transport started pubkey=6921d969fc2837a639f771b7b005f90c21ab4a847f54c414cd1316d3ed6665c1
2026-04-03T06:30:10.729319Z  INFO nostr_relay_pool::relay::inner: Connected to 'wss://relay.damus.io'
Published announcement: ee7814cd8277864b66b1ce830f30947df0a54e46d35e70855dd9080a5a26c5af
Gateway running. Waiting for requests...
Request from c1840152: Some("tools/list")
```


Running proxy:
```
    Running `target/debug/examples/proxy 6921d969fc2837a639f771b7b005f90c21ab4a847f54c414cd1316d3ed6665c1`
Client pubkey: c18401526e12212264da28a84406925afcee3cb03283b5d274b2ef1a6327b48d
2026-04-03T06:30:40.719397Z  INFO contextvm_sdk::transport::client: Client transport started pubkey=c18401526e12212264da28a84406925afcee3cb03283b5d274b2ef1a6327b48d
Sending tools/list request...
2026-04-03T06:30:41.252806Z  INFO nostr_relay_pool::relay::inner: Connected to 'wss://relay.damus.io'
2026-04-03T06:30:42.280515Z  WARN contextvm_sdk::transport::client: Response for unknown request e_tag=24d11429eb8284e5283fe1b66507e1c957234c26a7f834777a4151ea22619023
```

### After

Running gateway:
```
     Running `target/debug/examples/gateway`
Server pubkey: 511d43e5b48e6bc6c71d659e79069703d57b7e9ed2c1bf07e445bcacadf4016c
2026-04-03T07:16:39.470847Z  INFO contextvm_sdk::transport::server: Server transport started pubkey=511d43e5b48e6bc6c71d659e79069703d57b7e9ed2c1bf07e445bcacadf4016c
2026-04-03T07:16:40.155101Z  INFO nostr_relay_pool::relay::inner: Connected to 'wss://relay.damus.io'
Published announcement: 29524ef7bcef27020c6f0703b930f0b69d54b056a0cc12cdf5224de826de663d
Gateway running. Waiting for requests...
Request from ae43305c: Some("tools/list")
```

Running proxy:
```
     Running `target/debug/examples/proxy 511d43e5b48e6bc6c71d659e79069703d57b7e9ed2c1bf07e445bcacadf4016c`
Client pubkey: ae43305c2504b8d33058383b562909801cfe733fd6a568860f5fed54e9a57a87
2026-04-03T07:16:51.951060Z  INFO contextvm_sdk::transport::client: Client transport started pubkey=ae43305c2504b8d33058383b562909801cfe733fd6a568860f5fed54e9a57a87
Sending tools/list request...
2026-04-03T07:16:52.648651Z  INFO nostr_relay_pool::relay::inner: Connected to 'wss://relay.damus.io'
Response: {
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "tools": [
      {
        "description": "Echoes back the input message",
        "inputSchema": {
          "properties": {
            "message": {
              "description": "Message to echo",
              "type": "string"
            }
          },
          "required": [
            "message"
          ],
          "type": "object"
        },
        "name": "echo"
      }
    ]
  }
}
2026-04-03T07:16:53.662753Z  INFO nostr_relay_pool::relay::inner: Completely disconnected from 'wss://relay.damus.io'
```

---


Updated src/transport/base.rs so send_mcp_message() returns the signed MCP event ID.

- For encrypted messages, this is the inner signed event ID.
- For unencrypted messages, this remains the event ID of the published signed event.
