### PR TITLE
Integrating RMCP to existing rust sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ nostr-sdk = { version = "0.43", features = ["nip59"] }
 
 # Logging
 tracing = "0.1"
-rmcp = "1.3.0"
 
 # Optional MCP integration (Rust equivalent to TS @modelcontextprotocol/sdk)
 rmcp = { version = "0.16.0", features = ["server", "client", "macros", "transport-worker"], optional = true }
@@ -35,4 +34,6 @@ rmcp = ["dep:rmcp"]
 
 [dev-dependencies]
 tokio-test = "0.4"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"
+schemars = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,14 @@ nostr-sdk = { version = "0.43", features = ["nip59"] }
 # Logging
 tracing = "0.1"
 
+# Optional MCP integration (Rust equivalent to TS @modelcontextprotocol/sdk)
+rmcp = { version = "0.16.0", features = ["server", "client", "macros", "transport-worker"], optional = true }
+
+[features]
+# Enable rmcp by default while keeping legacy APIs available.
+default = ["rmcp"]
+rmcp = ["dep:rmcp"]
+
 [dev-dependencies]
 tokio-test = "0.4"
 tracing-subscriber = "0.3"

--- a/examples/discovery.rs
+++ b/examples/discovery.rs
@@ -53,8 +53,7 @@ async fn main() -> contextvm_sdk::Result<()> {
             println!("  Resources: {} found", resources.len());
         }
 
-        let prompts =
-            discovery::discover_prompts(client, &server.pubkey_parsed, &relays).await?;
+        let prompts = discovery::discover_prompts(client, &server.pubkey_parsed, &relays).await?;
         if !prompts.is_empty() {
             println!("  Prompts: {} found", prompts.len());
         }

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -42,7 +42,10 @@ async fn main() -> contextvm_sdk::Result<()> {
 
     // Wait for response
     if let Some(response) = rx.recv().await {
-        println!("Response: {}", serde_json::to_string_pretty(&response).unwrap());
+        println!(
+            "Response: {}",
+            serde_json::to_string_pretty(&response).unwrap()
+        );
     }
 
     proxy.stop().await?;

--- a/examples/rmcp_integration_test.rs
+++ b/examples/rmcp_integration_test.rs
@@ -17,7 +17,7 @@
 //!   cargo run --example rmcp_integration_test --features rmcp -- all wss://relay.primal.net
 
 use anyhow::{anyhow, bail, Context, Result};
-use contextvm_sdk::core::constants::MCP_PROTOCOL_VERSION;
+use contextvm_sdk::core::constants::mcp_protocol_version;
 use contextvm_sdk::core::types::{
     EncryptionMode, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
     ServerInfo as CtxServerInfo,
@@ -359,7 +359,7 @@ async fn run_hybrid_relay_case(relay_url: &str) -> Result<()> {
             id: init_id.clone(),
             method: "initialize".to_string(),
             params: Some(serde_json::json!({
-                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "protocolVersion": mcp_protocol_version(),
                 "capabilities": {
                     "tools": {},
                     "resources": {}
@@ -654,7 +654,7 @@ fn assert_initialize_shape(response: &JsonRpcMessage) -> Result<()> {
     let JsonRpcMessage::Response(resp) = response else {
         bail!("expected initialize response, got {response:?}");
     };
-
+    let expected_protocol = mcp_protocol_version();
     let protocol = resp
         .result
         .get("protocolVersion")
@@ -663,7 +663,7 @@ fn assert_initialize_shape(response: &JsonRpcMessage) -> Result<()> {
 
     if !is_supported_protocol(protocol) {
         bail!(
-            "unexpected protocolVersion in initialize response: expected one of [{MCP_PROTOCOL_VERSION}, {}], got {protocol}",
+            "unexpected protocolVersion in initialize response: expected one of [{expected_protocol}, {}], got {protocol}",
             ProtocolVersion::LATEST
         );
     }
@@ -676,7 +676,7 @@ fn assert_initialize_shape(response: &JsonRpcMessage) -> Result<()> {
 }
 
 fn is_supported_protocol(protocol: &str) -> bool {
-    protocol == MCP_PROTOCOL_VERSION || protocol == ProtocolVersion::LATEST.to_string()
+    protocol == mcp_protocol_version() || protocol == ProtocolVersion::LATEST.to_string()
 }
 
 fn assert_error_response(response: &JsonRpcMessage) -> Result<()> {

--- a/examples/rmcp_integration_test.rs
+++ b/examples/rmcp_integration_test.rs
@@ -1,0 +1,726 @@
+//! Comprehensive rmcp integration matrix for ContextVM SDK.
+//!
+//! This example validates three scenarios:
+//! 1) local rmcp transport (in-process duplex)
+//! 2) hybrid relay mode (rmcp server + legacy JSON-RPC client)
+//! 3) full rmcp over relays (rmcp server + rmcp client)
+//!
+//! Run:
+//!   cargo run --example rmcp_integration_test --features rmcp
+//!   cargo run --example rmcp_integration_test --features rmcp -- local
+//!   cargo run --example rmcp_integration_test --features rmcp -- hybrid
+//!   cargo run --example rmcp_integration_test --features rmcp -- relay-rmcp
+//!   cargo run --example rmcp_integration_test --features rmcp -- all
+//!
+//! Optional relay override:
+//!   CTXVM_RELAY_URL=wss://relay.primal.net cargo run --example rmcp_integration_test --features rmcp -- all
+//!   cargo run --example rmcp_integration_test --features rmcp -- all wss://relay.primal.net
+
+use anyhow::{anyhow, bail, Context, Result};
+use contextvm_sdk::core::constants::MCP_PROTOCOL_VERSION;
+use contextvm_sdk::core::types::{
+    EncryptionMode, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, ServerInfo as CtxServerInfo,
+};
+use contextvm_sdk::gateway::{GatewayConfig, NostrMCPGateway};
+use contextvm_sdk::proxy::{NostrMCPProxy, ProxyConfig};
+use contextvm_sdk::signer;
+use contextvm_sdk::transport::client::NostrClientTransportConfig;
+use contextvm_sdk::transport::server::NostrServerTransportConfig;
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::*,
+    schemars,
+    service::RequestContext,
+    tool, tool_handler, tool_router, ClientHandler, RoleServer, ServerHandler, ServiceExt,
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, timeout};
+
+const DEFAULT_RELAY_URL: &str = "wss://relay.primal.net";
+const IO_TIMEOUT: Duration = Duration::from_secs(30);
+const RELAY_WARMUP: Duration = Duration::from_secs(2);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Local,
+    Hybrid,
+    RelayRmcp,
+    All,
+}
+
+impl Mode {
+    fn parse(value: Option<&str>) -> Result<Self> {
+        match value.unwrap_or("all") {
+            "local" => Ok(Self::Local),
+            "hybrid" => Ok(Self::Hybrid),
+            "relay-rmcp" => Ok(Self::RelayRmcp),
+            "all" => Ok(Self::All),
+            other => bail!(
+                "Unknown mode '{other}'. Use one of: local | hybrid | relay-rmcp | all"
+            ),
+        }
+    }
+
+    fn run_local(self) -> bool {
+        matches!(self, Self::Local | Self::All)
+    }
+
+    fn run_hybrid(self) -> bool {
+        matches!(self, Self::Hybrid | Self::All)
+    }
+
+    fn run_relay_rmcp(self) -> bool {
+        matches!(self, Self::RelayRmcp | Self::All)
+    }
+}
+
+// Parameter structs with JSON schema for tools/list.
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct EchoParams {
+    message: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AddParams {
+    a: i64,
+    b: i64,
+}
+
+use rmcp::handler::server::router::tool::ToolRouter;
+
+#[derive(Clone)]
+struct DemoServer {
+    echo_count: Arc<Mutex<u32>>,
+    tool_router: ToolRouter<DemoServer>,
+}
+
+impl DemoServer {
+    fn new() -> Self {
+        Self {
+            echo_count: Arc::new(Mutex::new(0)),
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl DemoServer {
+    #[tool(description = "Echo a message back unchanged")]
+    async fn echo(
+        &self,
+        Parameters(EchoParams { message }): Parameters<EchoParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut n = self.echo_count.lock().await;
+        *n += 1;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Echo #{n}: {message}"
+        ))]))
+    }
+
+    #[tool(description = "Add two integers and return their sum")]
+    fn add(
+        &self,
+        Parameters(AddParams { a, b }): Parameters<AddParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{a} + {b} = {}",
+            a + b
+        ))]))
+    }
+
+    #[tool(description = "Return the total number of echo calls made so far")]
+    async fn get_echo_count(&self) -> Result<CallToolResult, ErrorData> {
+        let n = self.echo_count.lock().await;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Total echo calls: {n}"
+        ))]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for DemoServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::LATEST,
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+            server_info: Implementation {
+                name: "contextvm-demo".to_string(),
+                title: Some("ContextVM Demo Server".to_string()),
+                version: "0.1.0".to_string(),
+                description: Some("Demonstrates rmcp integration over ContextVM".to_string()),
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some("Try: echo, add, get_echo_count".to_string()),
+        }
+    }
+
+    async fn list_resources(
+        &self,
+        _req: Option<PaginatedRequestParams>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        Ok(ListResourcesResult {
+            resources: vec![
+                RawResource::new("demo://readme", "Demo README".to_string()).no_annotation(),
+            ],
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        req: ReadResourceRequestParams,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        match req.uri.as_str() {
+            "demo://readme" => Ok(ReadResourceResult {
+                contents: vec![ResourceContents::text(
+                    "This server demonstrates the ContextVM rmcp integration.",
+                    req.uri,
+                )],
+            }),
+            other => Err(ErrorData::resource_not_found(
+                "not_found",
+                Some(serde_json::json!({ "uri": other })),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct DemoClient;
+impl ClientHandler for DemoClient {}
+
+#[derive(Clone, Default)]
+struct RelayRmcpClient;
+impl ClientHandler for RelayRmcpClient {}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("rmcp=warn".parse()?)
+                .add_directive("contextvm_sdk=info".parse()?),
+        )
+        .init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mode = Mode::parse(args.first().map(String::as_str))?;
+    let relay_url = args
+        .get(1)
+        .cloned()
+        .or_else(|| std::env::var("CTXVM_RELAY_URL").ok())
+        .unwrap_or_else(|| DEFAULT_RELAY_URL.to_string());
+
+    println!("========================================");
+    println!("ContextVM SDK rmcp integration matrix");
+    println!("mode: {:?}", mode);
+    println!("relay: {relay_url}");
+    println!("========================================\n");
+
+    if mode.run_local() {
+        run_local_rmcp_case().await?;
+    }
+
+    if mode.run_hybrid() {
+        run_hybrid_relay_case(&relay_url).await?;
+    }
+
+    if mode.run_relay_rmcp() {
+        run_relay_rmcp_case(&relay_url).await?;
+    }
+
+    println!("\nAll selected integration scenarios passed.");
+    Ok(())
+}
+
+async fn run_local_rmcp_case() -> Result<()> {
+    println!("[local-rmcp] start");
+
+    let (server_io, client_io) = tokio::io::duplex(65536);
+
+    let server_handle = tokio::spawn(async move {
+        DemoServer::new()
+            .serve(server_io)
+            .await
+            .expect("server serve failed")
+            .waiting()
+            .await
+            .expect("server error");
+    });
+
+    let client = DemoClient.serve(client_io).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert_eq!(tools.len(), 3, "expected 3 tools in local rmcp case");
+
+    let add_result = client
+        .call_tool(call_params(
+            "add",
+            Some(serde_json::json!({ "a": 7, "b": 5 })),
+        ))
+        .await?;
+    let add_text = first_text(&add_result);
+    assert!(add_text.contains("12"), "expected add result to include 12");
+
+    let resources = client.list_all_resources().await?;
+    assert_eq!(resources.len(), 1, "expected one resource in local rmcp case");
+
+    match client.call_tool(call_params("no_such_tool", None)).await {
+        Err(_) => {}
+        Ok(r) if r.is_error.unwrap_or(false) => {}
+        Ok(_) => bail!("expected unknown tool to fail in local rmcp case"),
+    }
+
+    client.cancel().await?;
+    server_handle.abort();
+
+    println!("[local-rmcp] pass");
+    Ok(())
+}
+
+async fn run_hybrid_relay_case(relay_url: &str) -> Result<()> {
+    println!("[relay-hybrid] start (rmcp server + legacy client)");
+
+    let server_keys = signer::generate();
+    let server_pubkey_hex = server_keys.public_key().to_hex();
+
+    println!("[relay-hybrid] stage: spawning rmcp server task");
+    let relay_url_owned = relay_url.to_string();
+    let server_task = tokio::spawn(async move {
+        let server = NostrMCPGateway::serve_handler(
+            server_keys,
+            server_config(&relay_url_owned),
+            DemoServer::new(),
+        )
+        .await
+        .with_context(|| {
+            format!("failed to start rmcp server on relay {relay_url_owned}")
+        })?;
+
+        let _ = server
+            .waiting()
+            .await
+            .map_err(|e| anyhow!("rmcp server exited with error: {e}"))?;
+
+        Err(anyhow!("rmcp server stopped unexpectedly"))
+    });
+
+    sleep(RELAY_WARMUP).await;
+
+    if server_task.is_finished() {
+        let res = server_task
+            .await
+            .map_err(|e| anyhow!("rmcp server task join error: {e}"))?;
+        return res.context("rmcp server task ended before client startup");
+    }
+
+    let outcome: Result<()> = async {
+        println!("[relay-hybrid] stage: creating legacy proxy client");
+
+        let mut proxy = timeout(
+            STARTUP_TIMEOUT,
+            NostrMCPProxy::new(
+                signer::generate(),
+                client_config(relay_url, server_pubkey_hex.clone()),
+            ),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "timed out creating legacy proxy client after {:?}",
+                STARTUP_TIMEOUT
+            )
+        })?
+        .context("failed to create legacy proxy client")?;
+
+        println!("[relay-hybrid] stage: starting legacy proxy transport");
+        let mut rx = timeout(STARTUP_TIMEOUT, proxy.start())
+            .await
+            .with_context(|| {
+                format!(
+                    "timed out starting legacy proxy transport after {:?}",
+                    STARTUP_TIMEOUT
+                )
+            })?
+            .context("failed to start legacy proxy")?;
+        println!("[relay-hybrid] stage: legacy proxy started");
+
+    let init_id = serde_json::json!(1);
+    let init_request = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: init_id.clone(),
+        method: "initialize".to_string(),
+        params: Some(serde_json::json!({
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": {},
+                "resources": {}
+            },
+            "clientInfo": {
+                "name": "legacy-hybrid-client",
+                "version": "0.1.0"
+            }
+        })),
+    });
+
+        let init_response =
+            send_legacy_request_and_wait(&proxy, &mut rx, init_request, &init_id).await?;
+        assert_initialize_shape(&init_response)?;
+
+        proxy
+            .send(&JsonRpcMessage::Notification(JsonRpcNotification {
+                jsonrpc: "2.0".to_string(),
+                method: "notifications/initialized".to_string(),
+                params: None,
+            }))
+            .await
+            .context("failed to send initialized notification")?;
+
+        let tools_id = serde_json::json!(2);
+        let tools_request = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: tools_id.clone(),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        let tools_response =
+            send_legacy_request_and_wait(&proxy, &mut rx, tools_request, &tools_id).await?;
+        let tools = extract_tools_list(&tools_response)?;
+        assert!(
+            tools
+                .iter()
+                .any(|t| t.get("name") == Some(&serde_json::json!("echo"))),
+            "expected echo tool in hybrid case"
+        );
+
+        let call_id = serde_json::json!(3);
+        let call_request = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: call_id.clone(),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "name": "echo",
+                "arguments": { "message": "legacy-client-hello" }
+            })),
+        });
+
+        let call_response = send_legacy_request_and_wait(&proxy, &mut rx, call_request, &call_id)
+            .await
+            .context("tools/call failed in hybrid case")?;
+        let echo_text = extract_first_content_text(&call_response)?;
+        assert!(
+            echo_text.contains("legacy-client-hello"),
+            "unexpected echo output in hybrid case: {echo_text}"
+        );
+
+        let unknown_id = serde_json::json!(4);
+        let unknown_request = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: unknown_id.clone(),
+            method: "tools/call".to_string(),
+            params: Some(serde_json::json!({
+                "name": "no_such_tool",
+                "arguments": {}
+            })),
+        });
+
+        let unknown_response =
+            send_legacy_request_and_wait(&proxy, &mut rx, unknown_request, &unknown_id).await?;
+        assert_error_response(&unknown_response)?;
+
+        proxy.stop().await.context("failed to stop legacy proxy")?;
+
+        Ok(())
+    }
+    .await;
+
+    server_task.abort();
+
+    if server_task.is_finished() {
+        let _ = server_task.await;
+    }
+
+    outcome?;
+
+    println!("[relay-hybrid] pass");
+    Ok(())
+}
+
+async fn run_relay_rmcp_case(relay_url: &str) -> Result<()> {
+    println!("[relay-rmcp] start (rmcp server + rmcp client)");
+
+    let server_keys = signer::generate();
+    let server_pubkey_hex = server_keys.public_key().to_hex();
+
+    println!("[relay-rmcp] stage: spawning rmcp server task");
+    let relay_url_owned = relay_url.to_string();
+    let server_task = tokio::spawn(async move {
+        let server = NostrMCPGateway::serve_handler(
+            server_keys,
+            server_config(&relay_url_owned),
+            DemoServer::new(),
+        )
+        .await
+        .with_context(|| {
+            format!("failed to start rmcp server on relay {relay_url_owned}")
+        })?;
+
+        let _ = server
+            .waiting()
+            .await
+            .map_err(|e| anyhow!("rmcp server exited with error: {e}"))?;
+
+        Err(anyhow!("rmcp server stopped unexpectedly"))
+    });
+
+    sleep(RELAY_WARMUP).await;
+
+    if server_task.is_finished() {
+        let res = server_task
+            .await
+            .map_err(|e| anyhow!("rmcp server task join error: {e}"))?;
+        return res.context("rmcp server task ended before rmcp client startup");
+    }
+
+    let outcome: Result<()> = async {
+        println!("[relay-rmcp] stage: starting rmcp relay client worker");
+
+        let client = timeout(
+            STARTUP_TIMEOUT,
+            NostrMCPProxy::serve_client_handler(
+                signer::generate(),
+                client_config(relay_url, server_pubkey_hex),
+                RelayRmcpClient,
+            ),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "timed out starting rmcp relay client worker after {:?}",
+                STARTUP_TIMEOUT
+            )
+        })?
+        .context("failed to start rmcp relay client")?;
+        println!("[relay-rmcp] stage: rmcp relay client started");
+
+        let peer = client
+            .peer_info()
+            .ok_or_else(|| anyhow!("rmcp relay client did not receive peer info"))?;
+        let negotiated = peer.protocol_version.to_string();
+        assert!(
+            is_supported_protocol(&negotiated),
+            "unexpected negotiated protocol version: {negotiated}"
+        );
+
+        let tools = client.list_all_tools().await?;
+        assert!(
+            tools.iter().any(|t| t.name == "echo"),
+            "expected echo tool in rmcp relay case"
+        );
+
+        let echo = client
+            .call_tool(call_params(
+                "echo",
+                Some(serde_json::json!({ "message": "rmcp-relay-hello" })),
+            ))
+            .await?;
+        let echo_text = first_text(&echo);
+        assert!(
+            echo_text.contains("rmcp-relay-hello"),
+            "unexpected rmcp relay echo output: {echo_text}"
+        );
+
+        let resources = client.list_all_resources().await?;
+        assert!(
+            resources.iter().any(|r| r.uri.as_str() == "demo://readme"),
+            "expected demo://readme resource in rmcp relay case"
+        );
+
+        match client.call_tool(call_params("no_such_tool", None)).await {
+            Err(_) => {}
+            Ok(r) if r.is_error.unwrap_or(false) => {}
+            Ok(_) => bail!("expected unknown tool to fail in rmcp relay case"),
+        }
+
+        client
+            .cancel()
+            .await
+            .context("failed to cancel rmcp relay client")?;
+
+        Ok(())
+    }
+    .await;
+
+    server_task.abort();
+
+    if server_task.is_finished() {
+        let _ = server_task.await;
+    }
+
+    outcome?;
+
+    println!("[relay-rmcp] pass");
+    Ok(())
+}
+
+fn server_config(relay_url: &str) -> GatewayConfig {
+    GatewayConfig {
+        nostr_config: NostrServerTransportConfig {
+            relay_urls: vec![relay_url.to_string()],
+            encryption_mode: EncryptionMode::Optional,
+            server_info: Some(CtxServerInfo {
+                name: Some("rmcp-matrix-server".to_string()),
+                about: Some("rmcp matrix coverage server".to_string()),
+                ..Default::default()
+            }),
+            is_announced_server: false,
+            ..Default::default()
+        },
+    }
+}
+
+fn client_config(relay_url: &str, server_pubkey: String) -> ProxyConfig {
+    ProxyConfig {
+        nostr_config: NostrClientTransportConfig {
+            relay_urls: vec![relay_url.to_string()],
+            server_pubkey,
+            encryption_mode: EncryptionMode::Optional,
+            ..Default::default()
+        },
+    }
+}
+
+async fn send_legacy_request_and_wait(
+    proxy: &NostrMCPProxy,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<JsonRpcMessage>,
+    request: JsonRpcMessage,
+    expected_id: &serde_json::Value,
+) -> Result<JsonRpcMessage> {
+    proxy.send(&request).await?;
+
+    loop {
+        let maybe_msg = timeout(IO_TIMEOUT, rx.recv())
+            .await
+            .context("timed out waiting for legacy response")?;
+
+        let msg = maybe_msg.ok_or_else(|| anyhow!("legacy response channel closed"))?;
+
+        if msg.id() == Some(expected_id) {
+            return Ok(msg);
+        }
+
+        if msg.is_notification() {
+            continue;
+        }
+    }
+}
+
+fn extract_tools_list(response: &JsonRpcMessage) -> Result<&Vec<serde_json::Value>> {
+    let JsonRpcMessage::Response(resp) = response else {
+        bail!("expected tools/list response, got {response:?}");
+    };
+
+    resp.result
+        .get("tools")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("tools/list response missing tools array"))
+}
+
+fn extract_first_content_text(response: &JsonRpcMessage) -> Result<String> {
+    let JsonRpcMessage::Response(resp) = response else {
+        bail!("expected tools/call response, got {response:?}");
+    };
+
+    let text = resp
+        .result
+        .get("content")
+        .and_then(|v| v.as_array())
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("text"))
+        .and_then(|text| text.as_str())
+        .ok_or_else(|| anyhow!("tools/call response missing content[0].text"))?;
+
+    Ok(text.to_string())
+}
+
+fn assert_initialize_shape(response: &JsonRpcMessage) -> Result<()> {
+    let JsonRpcMessage::Response(resp) = response else {
+        bail!("expected initialize response, got {response:?}");
+    };
+
+    let protocol = resp
+        .result
+        .get("protocolVersion")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("initialize response missing protocolVersion"))?;
+
+    if !is_supported_protocol(protocol) {
+        bail!(
+            "unexpected protocolVersion in initialize response: expected one of [{MCP_PROTOCOL_VERSION}, {}], got {protocol}",
+            ProtocolVersion::LATEST
+        );
+    }
+
+    if resp.result.get("serverInfo").is_none() {
+        bail!("initialize response missing serverInfo");
+    }
+
+    Ok(())
+}
+
+fn is_supported_protocol(protocol: &str) -> bool {
+    protocol == MCP_PROTOCOL_VERSION || protocol == ProtocolVersion::LATEST.to_string()
+}
+
+fn assert_error_response(response: &JsonRpcMessage) -> Result<()> {
+    match response {
+        JsonRpcMessage::ErrorResponse(err) => {
+            if err.error.code >= 0 {
+                bail!("expected negative JSON-RPC error code, got {}", err.error.code);
+            }
+            Ok(())
+        }
+        JsonRpcMessage::Response(resp) => {
+            if resp.result.get("isError") == Some(&serde_json::json!(true)) {
+                Ok(())
+            } else {
+                bail!("expected error response but received success result")
+            }
+        }
+        _ => bail!("expected error response, got {response:?}"),
+    }
+}
+
+fn call_params(name: &'static str, args: Option<serde_json::Value>) -> CallToolRequestParams {
+    CallToolRequestParams {
+        name: name.into(),
+        arguments: args.and_then(|v| serde_json::from_value(v).ok()),
+        meta: None,
+        task: None,
+    }
+}
+
+fn first_text(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .find_map(|content| {
+            if let RawContent::Text(t) = &content.raw {
+                Some(t.text.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}

--- a/examples/rmcp_integration_test.rs
+++ b/examples/rmcp_integration_test.rs
@@ -19,7 +19,8 @@
 use anyhow::{anyhow, bail, Context, Result};
 use contextvm_sdk::core::constants::MCP_PROTOCOL_VERSION;
 use contextvm_sdk::core::types::{
-    EncryptionMode, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, ServerInfo as CtxServerInfo,
+    EncryptionMode, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
+    ServerInfo as CtxServerInfo,
 };
 use contextvm_sdk::gateway::{GatewayConfig, NostrMCPGateway};
 use contextvm_sdk::proxy::{NostrMCPProxy, ProxyConfig};
@@ -27,11 +28,8 @@ use contextvm_sdk::signer;
 use contextvm_sdk::transport::client::NostrClientTransportConfig;
 use contextvm_sdk::transport::server::NostrServerTransportConfig;
 use rmcp::{
-    handler::server::wrapper::Parameters,
-    model::*,
-    schemars,
-    service::RequestContext,
-    tool, tool_handler, tool_router, ClientHandler, RoleServer, ServerHandler, ServiceExt,
+    handler::server::wrapper::Parameters, model::*, schemars, service::RequestContext, tool,
+    tool_handler, tool_router, ClientHandler, RoleServer, ServerHandler, ServiceExt,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -58,9 +56,7 @@ impl Mode {
             "hybrid" => Ok(Self::Hybrid),
             "relay-rmcp" => Ok(Self::RelayRmcp),
             "all" => Ok(Self::All),
-            other => bail!(
-                "Unknown mode '{other}'. Use one of: local | hybrid | relay-rmcp | all"
-            ),
+            other => bail!("Unknown mode '{other}'. Use one of: local | hybrid | relay-rmcp | all"),
         }
     }
 
@@ -168,7 +164,7 @@ impl ServerHandler for DemoServer {
     ) -> Result<ListResourcesResult, ErrorData> {
         Ok(ListResourcesResult {
             resources: vec![
-                RawResource::new("demo://readme", "Demo README".to_string()).no_annotation(),
+                RawResource::new("demo://readme", "Demo README".to_string()).no_annotation()
             ],
             next_cursor: None,
             meta: None,
@@ -273,7 +269,11 @@ async fn run_local_rmcp_case() -> Result<()> {
     assert!(add_text.contains("12"), "expected add result to include 12");
 
     let resources = client.list_all_resources().await?;
-    assert_eq!(resources.len(), 1, "expected one resource in local rmcp case");
+    assert_eq!(
+        resources.len(),
+        1,
+        "expected one resource in local rmcp case"
+    );
 
     match client.call_tool(call_params("no_such_tool", None)).await {
         Err(_) => {}
@@ -303,9 +303,7 @@ async fn run_hybrid_relay_case(relay_url: &str) -> Result<()> {
             DemoServer::new(),
         )
         .await
-        .with_context(|| {
-            format!("failed to start rmcp server on relay {relay_url_owned}")
-        })?;
+        .with_context(|| format!("failed to start rmcp server on relay {relay_url_owned}"))?;
 
         let _ = server
             .waiting()
@@ -355,23 +353,23 @@ async fn run_hybrid_relay_case(relay_url: &str) -> Result<()> {
             .context("failed to start legacy proxy")?;
         println!("[relay-hybrid] stage: legacy proxy started");
 
-    let init_id = serde_json::json!(1);
-    let init_request = JsonRpcMessage::Request(JsonRpcRequest {
-        jsonrpc: "2.0".to_string(),
-        id: init_id.clone(),
-        method: "initialize".to_string(),
-        params: Some(serde_json::json!({
-            "protocolVersion": MCP_PROTOCOL_VERSION,
-            "capabilities": {
-                "tools": {},
-                "resources": {}
-            },
-            "clientInfo": {
-                "name": "legacy-hybrid-client",
-                "version": "0.1.0"
-            }
-        })),
-    });
+        let init_id = serde_json::json!(1);
+        let init_request = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: init_id.clone(),
+            method: "initialize".to_string(),
+            params: Some(serde_json::json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": {},
+                    "resources": {}
+                },
+                "clientInfo": {
+                    "name": "legacy-hybrid-client",
+                    "version": "0.1.0"
+                }
+            })),
+        });
 
         let init_response =
             send_legacy_request_and_wait(&proxy, &mut rx, init_request, &init_id).await?;
@@ -472,9 +470,7 @@ async fn run_relay_rmcp_case(relay_url: &str) -> Result<()> {
             DemoServer::new(),
         )
         .await
-        .with_context(|| {
-            format!("failed to start rmcp server on relay {relay_url_owned}")
-        })?;
+        .with_context(|| format!("failed to start rmcp server on relay {relay_url_owned}"))?;
 
         let _ = server
             .waiting()
@@ -687,7 +683,10 @@ fn assert_error_response(response: &JsonRpcMessage) -> Result<()> {
     match response {
         JsonRpcMessage::ErrorResponse(err) => {
             if err.error.code >= 0 {
-                bail!("expected negative JSON-RPC error code, got {}", err.error.code);
+                bail!(
+                    "expected negative JSON-RPC error code, got {}",
+                    err.error.code
+                );
             }
             Ok(())
         }

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -33,6 +33,7 @@ pub const RESOURCETEMPLATES_LIST_KIND: u16 = 11319;
 /// Prompts list (addressable, kind 11320)
 pub const PROMPTS_LIST_KIND: u16 = 11320;
 
+pub const KIND_GIFT_WRAP: u16 = 1059;
 /// Nostr tag constants
 pub mod tags {
     /// Public key tag
@@ -73,7 +74,6 @@ pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
 ///
 /// Matches the `protocolVersion` field of the `InitializeResult` JSON-RPC response.
 /// Keep this in sync with the MCP spec and rmcp's `ProtocolVersion::LATEST`.
-pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 
 /// Default LRU cache size for deduplication
 pub const DEFAULT_LRU_SIZE: usize = 5000;
@@ -108,6 +108,21 @@ pub const UNENCRYPTED_KINDS: &[u16] = &[
     RESOURCETEMPLATES_LIST_KIND,
     PROMPTS_LIST_KIND,
 ];
+
+
+#[cfg(feature = "rmcp")]
+pub fn mcp_protocol_version() -> &'static str {
+    use std::sync::OnceLock;
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION
+        .get_or_init(|| rmcp::model::ProtocolVersion::LATEST.to_string())
+        .as_str()
+}
+
+#[cfg(not(feature = "rmcp"))]
+pub const fn mcp_protocol_version() -> &'static str {
+    "2025-11-25"
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -69,6 +69,12 @@ pub mod tags {
 /// Maximum message size (1MB)
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
 
+/// MCP protocol version string used in initialize responses.
+///
+/// Matches the `protocolVersion` field of the `InitializeResult` JSON-RPC response.
+/// Keep this in sync with the MCP spec and rmcp's `ProtocolVersion::LATEST`.
+pub const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+
 /// Default LRU cache size for deduplication
 pub const DEFAULT_LRU_SIZE: usize = 5000;
 

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -217,4 +217,3 @@ mod tests {
         assert!(!UNENCRYPTED_KINDS.contains(&EPHEMERAL_GIFT_WRAP_KIND));
     }
 }
-

--- a/src/core/serializers.rs
+++ b/src/core/serializers.rs
@@ -50,7 +50,7 @@ pub fn get_tag_value_from_slice(tags: &[Tag], name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::types::{JsonRpcRequest, JsonRpcMessage};
+    use crate::core::types::{JsonRpcMessage, JsonRpcRequest};
 
     #[test]
     fn test_roundtrip() {

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -120,6 +120,50 @@ pub async fn discover_resource_templates(
     .await
 }
 
+/// Discover tools and parse them into rmcp typed descriptors.
+#[cfg(feature = "rmcp")]
+pub async fn discover_tools_typed(
+    client: &Arc<Client>,
+    server_pubkey: &PublicKey,
+    relay_urls: &[String],
+) -> Result<Vec<rmcp::model::Tool>> {
+    let raw = discover_tools(client, server_pubkey, relay_urls).await?;
+    parse_typed_list(raw)
+}
+
+/// Discover resources and parse them into rmcp typed descriptors.
+#[cfg(feature = "rmcp")]
+pub async fn discover_resources_typed(
+    client: &Arc<Client>,
+    server_pubkey: &PublicKey,
+    relay_urls: &[String],
+) -> Result<Vec<rmcp::model::Resource>> {
+    let raw = discover_resources(client, server_pubkey, relay_urls).await?;
+    parse_typed_list(raw)
+}
+
+/// Discover prompts and parse them into rmcp typed descriptors.
+#[cfg(feature = "rmcp")]
+pub async fn discover_prompts_typed(
+    client: &Arc<Client>,
+    server_pubkey: &PublicKey,
+    relay_urls: &[String],
+) -> Result<Vec<rmcp::model::Prompt>> {
+    let raw = discover_prompts(client, server_pubkey, relay_urls).await?;
+    parse_typed_list(raw)
+}
+
+/// Discover resource templates and parse them into rmcp typed descriptors.
+#[cfg(feature = "rmcp")]
+pub async fn discover_resource_templates_typed(
+    client: &Arc<Client>,
+    server_pubkey: &PublicKey,
+    relay_urls: &[String],
+) -> Result<Vec<rmcp::model::ResourceTemplate>> {
+    let raw = discover_resource_templates(client, server_pubkey, relay_urls).await?;
+    parse_typed_list(raw)
+}
+
 // ── Internal ────────────────────────────────────────────────────────
 
 async fn fetch_list(
@@ -151,6 +195,20 @@ async fn fetch_list(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default())
+}
+
+#[cfg(feature = "rmcp")]
+fn parse_typed_list<T>(raw: Vec<serde_json::Value>) -> Result<Vec<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let mut parsed = Vec::new();
+    for item in raw {
+        let value = serde_json::from_value(item)
+            .map_err(|e| Error::Other(format!("Failed to parse typed discovery item: {e}")))?;
+        parsed.push(value);
+    }
+    Ok(parsed)
 }
 
 #[cfg(test)]

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -64,8 +64,7 @@ pub async fn discover_servers(
 
     let mut announcements = Vec::new();
     for event in events {
-        let server_info: ServerInfo =
-            serde_json::from_str(&event.content).unwrap_or_default();
+        let server_info: ServerInfo = serde_json::from_str(&event.content).unwrap_or_default();
         announcements.push(ServerAnnouncement {
             pubkey: event.pubkey.to_hex(),
             pubkey_parsed: event.pubkey,
@@ -233,7 +232,10 @@ mod tests {
         assert_eq!(parsed.version, Some("1.0.0".to_string()));
         assert_eq!(parsed.about, Some("A test MCP server".to_string()));
         assert_eq!(parsed.website, Some("https://example.com".to_string()));
-        assert_eq!(parsed.picture, Some("https://example.com/pic.png".to_string()));
+        assert_eq!(
+            parsed.picture,
+            Some("https://example.com/pic.png".to_string())
+        );
     }
 
     #[test]
@@ -280,7 +282,8 @@ mod tests {
             },
             event_id: EventId::from_hex(
                 "0000000000000000000000000000000000000000000000000000000000000001",
-            ).unwrap(),
+            )
+            .unwrap(),
             created_at: Timestamp::now(),
         };
 

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -111,6 +111,8 @@ pub async fn gift_wrap(
 
 #[cfg(test)]
 mod tests {
+    use crate::core::constants::KIND_GIFT_WRAP;
+
     use super::*;
 
     #[tokio::test]
@@ -139,7 +141,10 @@ mod tests {
     ///   2. NIP-44 encrypt the plaintext using ephemeral_secret + recipient_pubkey
     ///   3. Build kind 1059 event with encrypted content, `p` tag = recipient
     ///   4. Sign with ephemeral key
-    async fn create_js_style_gift_wrap(plaintext: &str, recipient: &PublicKey) -> (Event, Keys) {
+    async fn create_simple_gift_wrap(
+        plaintext: &str,
+        recipient: &PublicKey,
+    ) -> (Event, Keys) {
         let ephemeral = Keys::generate();
 
         // Single-layer NIP-44 encrypt
@@ -148,8 +153,8 @@ mod tests {
             .unwrap();
 
         // Build kind 1059 event
-        let builder =
-            EventBuilder::new(Kind::Custom(1059), encrypted).tag(Tag::public_key(*recipient));
+        let builder = EventBuilder::new(Kind::from(KIND_GIFT_WRAP), encrypted)
+            .tag(Tag::public_key(*recipient));
 
         let event = builder.sign_with_keys(&ephemeral).unwrap();
         (event, ephemeral)
@@ -177,7 +182,7 @@ mod tests {
 
         // Step 3: Encrypt as a gift wrap
         let (gift_wrap, _ephemeral) =
-            create_js_style_gift_wrap(&inner_json, &server_keys.public_key()).await;
+            create_simple_gift_wrap(&inner_json, &server_keys.public_key()).await;
 
         assert_eq!(gift_wrap.kind, Kind::Custom(1059));
 

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -43,10 +43,7 @@ where
 /// - The gift wrap event has NIP-44 encrypted content (single layer)
 /// - Decrypt using recipient's key + event's pubkey (ephemeral sender)
 /// - Returns the decrypted plaintext content string
-pub async fn decrypt_gift_wrap_single_layer<T>(
-    signer: &T,
-    event: &Event,
-) -> Result<String>
+pub async fn decrypt_gift_wrap_single_layer<T>(signer: &T, event: &Event) -> Result<String>
 where
     T: NostrSigner,
 {
@@ -73,8 +70,8 @@ where
 
     let encrypted = encrypt_nip44(&ephemeral, recipient, plaintext).await?;
 
-    let builder = EventBuilder::new(Kind::Custom(GIFT_WRAP_KIND), encrypted)
-        .tag(Tag::public_key(*recipient));
+    let builder =
+        EventBuilder::new(Kind::Custom(GIFT_WRAP_KIND), encrypted).tag(Tag::public_key(*recipient));
 
     builder
         .sign_with_keys(&ephemeral)
@@ -142,10 +139,7 @@ mod tests {
     ///   2. NIP-44 encrypt the plaintext using ephemeral_secret + recipient_pubkey
     ///   3. Build kind 1059 event with encrypted content, `p` tag = recipient
     ///   4. Sign with ephemeral key
-    async fn create_js_style_gift_wrap(
-        plaintext: &str,
-        recipient: &PublicKey,
-    ) -> (Event, Keys) {
+    async fn create_js_style_gift_wrap(plaintext: &str, recipient: &PublicKey) -> (Event, Keys) {
         let ephemeral = Keys::generate();
 
         // Single-layer NIP-44 encrypt
@@ -154,8 +148,8 @@ mod tests {
             .unwrap();
 
         // Build kind 1059 event
-        let builder = EventBuilder::new(Kind::Custom(1059), encrypted)
-            .tag(Tag::public_key(*recipient));
+        let builder =
+            EventBuilder::new(Kind::Custom(1059), encrypted).tag(Tag::public_key(*recipient));
 
         let event = builder.sign_with_keys(&ephemeral).unwrap();
         (event, ephemeral)

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -81,6 +81,32 @@ impl NostrMCPGateway {
     }
 }
 
+#[cfg(feature = "rmcp")]
+impl NostrMCPGateway {
+    /// Start a gateway directly from an rmcp server handler.
+    ///
+    /// This additive API keeps the existing `new/start/send_response` flow intact,
+    /// while allowing rmcp-first usage through the worker adapter.
+    pub async fn serve_handler<T, H>(
+        signer: T,
+        config: GatewayConfig,
+        handler: H,
+    ) -> Result<rmcp::service::RunningService<rmcp::RoleServer, H>>
+    where
+        T: nostr_sdk::prelude::IntoNostrSigner,
+        H: rmcp::ServerHandler,
+    {
+        use crate::rmcp_transport::NostrServerWorker;
+        use rmcp::ServiceExt;
+
+        let worker = NostrServerWorker::new(signer, config.nostr_config).await?;
+        handler
+            .serve(worker)
+            .await
+            .map_err(|e| Error::Other(format!("rmcp server initialization failed: {e}")))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -40,9 +40,7 @@ impl NostrMCPGateway {
     ///
     /// The caller is responsible for processing requests and calling
     /// `send_response` for each one.
-    pub async fn start(
-        &mut self,
-    ) -> Result<tokio::sync::mpsc::UnboundedReceiver<IncomingRequest>> {
+    pub async fn start(&mut self) -> Result<tokio::sync::mpsc::UnboundedReceiver<IncomingRequest>> {
         if self.is_running {
             return Err(Error::Other("Gateway already running".to_string()));
         }
@@ -133,11 +131,27 @@ mod tests {
 
         let config = GatewayConfig { nostr_config };
 
-        assert_eq!(config.nostr_config.relay_urls, vec!["wss://relay.example.com"]);
-        assert_eq!(config.nostr_config.encryption_mode, EncryptionMode::Required);
+        assert_eq!(
+            config.nostr_config.relay_urls,
+            vec!["wss://relay.example.com"]
+        );
+        assert_eq!(
+            config.nostr_config.encryption_mode,
+            EncryptionMode::Required
+        );
         assert!(config.nostr_config.is_announced_server);
         assert_eq!(config.nostr_config.allowed_public_keys.len(), 1);
-        assert!(config.nostr_config.server_info.as_ref().unwrap().name.as_ref().unwrap() == "Test Gateway");
+        assert!(
+            config
+                .nostr_config
+                .server_info
+                .as_ref()
+                .unwrap()
+                .name
+                .as_ref()
+                .unwrap()
+                == "Test Gateway"
+        );
     }
 
     #[test]
@@ -145,7 +159,10 @@ mod tests {
         let config = GatewayConfig {
             nostr_config: NostrServerTransportConfig::default(),
         };
-        assert_eq!(config.nostr_config.encryption_mode, EncryptionMode::Optional);
+        assert_eq!(
+            config.nostr_config.encryption_mode,
+            EncryptionMode::Optional
+        );
         assert!(!config.nostr_config.is_announced_server);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ pub mod relay;
 pub mod signer;
 pub mod transport;
 
+#[cfg(feature = "rmcp")]
+pub mod rmcp_transport;
+
 // Re-export commonly used types
 pub use core::error::{Error, Result};
 pub use core::types::{
@@ -55,3 +58,6 @@ pub use discovery::ServerAnnouncement;
 pub use relay::RelayPool;
 pub use transport::client::{NostrClientTransport, NostrClientTransportConfig};
 pub use transport::server::{IncomingRequest, NostrServerTransport, NostrServerTransportConfig};
+
+#[cfg(feature = "rmcp")]
+pub use rmcp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod proxy;
 pub mod relay;
 pub mod signer;
 pub mod transport;
+pub mod util;
 
 #[cfg(feature = "rmcp")]
 pub mod rmcp_transport;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -70,6 +70,32 @@ impl NostrMCPProxy {
     }
 }
 
+#[cfg(feature = "rmcp")]
+impl NostrMCPProxy {
+    /// Start a proxy directly from an rmcp client handler.
+    ///
+    /// This additive API keeps the existing `new/start/send` flow intact,
+    /// while allowing rmcp-first usage through the worker adapter.
+    pub async fn serve_client_handler<T, H>(
+        signer: T,
+        config: ProxyConfig,
+        handler: H,
+    ) -> Result<rmcp::service::RunningService<rmcp::RoleClient, H>>
+    where
+        T: nostr_sdk::prelude::IntoNostrSigner,
+        H: rmcp::ClientHandler,
+    {
+        use crate::rmcp_transport::NostrClientWorker;
+        use rmcp::ServiceExt;
+
+        let worker = NostrClientWorker::new(signer, config.nostr_config).await?;
+        handler
+            .serve(worker)
+            .await
+            .map_err(|e| Error::Other(format!("rmcp client initialization failed: {e}")))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -34,9 +34,7 @@ impl NostrMCPProxy {
     }
 
     /// Start the proxy. Returns a receiver for incoming responses/notifications.
-    pub async fn start(
-        &mut self,
-    ) -> Result<tokio::sync::mpsc::UnboundedReceiver<JsonRpcMessage>> {
+    pub async fn start(&mut self) -> Result<tokio::sync::mpsc::UnboundedReceiver<JsonRpcMessage>> {
         if self.is_running {
             return Err(Error::Other("Proxy already running".to_string()));
         }
@@ -118,9 +116,15 @@ mod tests {
 
         let config = ProxyConfig { nostr_config };
 
-        assert_eq!(config.nostr_config.relay_urls, vec!["wss://relay.example.com"]);
+        assert_eq!(
+            config.nostr_config.relay_urls,
+            vec!["wss://relay.example.com"]
+        );
         assert_eq!(config.nostr_config.server_pubkey, server_pubkey);
-        assert_eq!(config.nostr_config.encryption_mode, EncryptionMode::Required);
+        assert_eq!(
+            config.nostr_config.encryption_mode,
+            EncryptionMode::Required
+        );
         assert!(config.nostr_config.is_stateless);
         assert_eq!(config.nostr_config.timeout, Duration::from_secs(60));
     }
@@ -131,6 +135,9 @@ mod tests {
             nostr_config: NostrClientTransportConfig::default(),
         };
         assert!(!config.nostr_config.is_stateless);
-        assert_eq!(config.nostr_config.encryption_mode, EncryptionMode::Optional);
+        assert_eq!(
+            config.nostr_config.encryption_mode,
+            EncryptionMode::Optional
+        );
     }
 }

--- a/src/rmcp_transport/convert.rs
+++ b/src/rmcp_transport/convert.rs
@@ -4,6 +4,7 @@
 //! compatibility and avoid fragile hand-mapping between evolving type systems.
 
 use crate::core::types::JsonRpcMessage;
+use crate::util::logger;
 
 /// Convert internal JSON-RPC message into rmcp server RX message.
 ///
@@ -12,8 +13,33 @@ use crate::core::types::JsonRpcMessage;
 pub fn internal_to_rmcp_server_rx(
     msg: &JsonRpcMessage,
 ) -> Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleServer>> {
-    let value = serde_json::to_value(msg).ok()?;
-    serde_json::from_value(value).ok()
+    let direction = "internal_to_rmcp_server_rx";
+    let target = "contextvm_sdk::rmcp_transport::convert";
+    let value = match serde_json::to_value(msg) {
+        Ok(value) => value,
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to serialize message into intermediate JSON: {error}"
+                ),
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_value(value.clone()) {
+        Ok(parsed) => Some(parsed),
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
+                ),
+            );
+            None
+        }
+    }
 }
 
 /// Convert internal JSON-RPC message into rmcp client RX message.
@@ -23,24 +49,99 @@ pub fn internal_to_rmcp_server_rx(
 pub fn internal_to_rmcp_client_rx(
     msg: &JsonRpcMessage,
 ) -> Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleClient>> {
-    let value = serde_json::to_value(msg).ok()?;
-    serde_json::from_value(value).ok()
+    let direction = "internal_to_rmcp_client_rx";
+    let target = "contextvm_sdk::rmcp_transport::convert";
+    let value = match serde_json::to_value(msg) {
+        Ok(value) => value,
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to serialize message into intermediate JSON: {error}"
+                ),
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_value(value.clone()) {
+        Ok(parsed) => Some(parsed),
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
+                ),
+            );
+            None
+        }
+    }
 }
 
 /// Convert rmcp server TX message back into internal JSON-RPC.
 pub fn rmcp_server_tx_to_internal(
     msg: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
 ) -> Option<JsonRpcMessage> {
-    let value = serde_json::to_value(msg).ok()?;
-    serde_json::from_value(value).ok()
+    let direction = "rmcp_server_tx_to_internal";
+    let target = "contextvm_sdk::rmcp_transport::convert";
+    let value = match serde_json::to_value(msg) {
+        Ok(value) => value,
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to serialize message into intermediate JSON: {error}"
+                ),
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_value(value.clone()) {
+        Ok(parsed) => Some(parsed),
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
+                ),
+            );
+            None
+        }
+    }
 }
 
 /// Convert rmcp client TX message back into internal JSON-RPC.
 pub fn rmcp_client_tx_to_internal(
     msg: rmcp::service::TxJsonRpcMessage<rmcp::RoleClient>,
 ) -> Option<JsonRpcMessage> {
-    let value = serde_json::to_value(msg).ok()?;
-    serde_json::from_value(value).ok()
+    let direction = "rmcp_client_tx_to_internal";
+    let target = "contextvm_sdk::rmcp_transport::convert";
+    let value = match serde_json::to_value(msg) {
+        Ok(value) => value,
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to serialize message into intermediate JSON: {error}"
+                ),
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_value(value.clone()) {
+        Ok(parsed) => Some(parsed),
+        Err(error) => {
+            logger::error_with_target(
+                target,
+                format!(
+                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
+                ),
+            );
+            None
+        }
+    }
 }
 
 #[cfg(all(test, feature = "rmcp"))]

--- a/src/rmcp_transport/convert.rs
+++ b/src/rmcp_transport/convert.rs
@@ -1,0 +1,44 @@
+//! Conversion boundary between internal JSON-RPC messages and rmcp message types.
+//!
+//! These helpers intentionally convert via serde JSON to preserve wire-level
+//! compatibility and avoid fragile hand-mapping between evolving type systems.
+
+use crate::core::types::JsonRpcMessage;
+
+/// Convert internal JSON-RPC message into rmcp server RX message.
+///
+/// Role mapping:
+/// - RoleServer RX receives client-originated messages.
+pub fn internal_to_rmcp_server_rx(
+    msg: &JsonRpcMessage,
+) -> Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleServer>> {
+    let value = serde_json::to_value(msg).ok()?;
+    serde_json::from_value(value).ok()
+}
+
+/// Convert internal JSON-RPC message into rmcp client RX message.
+///
+/// Role mapping:
+/// - RoleClient RX receives server-originated messages.
+pub fn internal_to_rmcp_client_rx(
+    msg: &JsonRpcMessage,
+) -> Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleClient>> {
+    let value = serde_json::to_value(msg).ok()?;
+    serde_json::from_value(value).ok()
+}
+
+/// Convert rmcp server TX message back into internal JSON-RPC.
+pub fn rmcp_server_tx_to_internal(
+    msg: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
+) -> Option<JsonRpcMessage> {
+    let value = serde_json::to_value(msg).ok()?;
+    serde_json::from_value(value).ok()
+}
+
+/// Convert rmcp client TX message back into internal JSON-RPC.
+pub fn rmcp_client_tx_to_internal(
+    msg: rmcp::service::TxJsonRpcMessage<rmcp::RoleClient>,
+) -> Option<JsonRpcMessage> {
+    let value = serde_json::to_value(msg).ok()?;
+    serde_json::from_value(value).ok()
+}

--- a/src/rmcp_transport/convert.rs
+++ b/src/rmcp_transport/convert.rs
@@ -42,3 +42,104 @@ pub fn rmcp_client_tx_to_internal(
     let value = serde_json::to_value(msg).ok()?;
     serde_json::from_value(value).ok()
 }
+
+#[cfg(all(test, feature = "rmcp"))]
+mod tests {
+    use super::*;
+    use crate::core::types::{JsonRpcRequest, JsonRpcResponse};
+
+    #[test]
+    fn test_internal_request_to_rmcp_server_rx_ping() {
+        let internal = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "ping".to_string(),
+            params: None,
+        });
+
+        let rmcp_msg = internal_to_rmcp_server_rx(&internal)
+            .expect("expected conversion to rmcp server rx message");
+        let value = serde_json::to_value(rmcp_msg).expect("serialize rmcp message to JSON");
+
+        assert_eq!(value.get("method"), Some(&serde_json::json!("ping")));
+        assert_eq!(value.get("id"), Some(&serde_json::json!(1)));
+    }
+
+    #[test]
+    fn test_internal_response_to_rmcp_client_rx_empty_result() {
+        let internal = JsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(42),
+            result: serde_json::json!({}),
+        });
+
+        let rmcp_msg = internal_to_rmcp_client_rx(&internal)
+            .expect("expected conversion to rmcp client rx message");
+        let value = serde_json::to_value(rmcp_msg).expect("serialize rmcp message to JSON");
+
+        assert_eq!(value.get("id"), Some(&serde_json::json!(42)));
+        assert_eq!(value.get("result"), Some(&serde_json::json!({})));
+    }
+
+    #[test]
+    fn test_rmcp_server_tx_to_internal_response() {
+        let rmcp_msg = rmcp::model::ServerJsonRpcMessage::response(
+            rmcp::model::ServerResult::empty(()),
+            rmcp::model::RequestId::Number(7),
+        );
+
+        let internal = rmcp_server_tx_to_internal(rmcp_msg)
+            .expect("expected conversion from rmcp server tx to internal JSON-RPC");
+
+        match internal {
+            JsonRpcMessage::Response(resp) => {
+                assert_eq!(resp.id, serde_json::json!(7));
+                assert_eq!(resp.result, serde_json::json!({}));
+            }
+            other => panic!("expected internal response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rmcp_client_tx_to_internal_response() {
+        let rmcp_msg = rmcp::model::ClientJsonRpcMessage::response(
+            rmcp::model::ClientResult::empty(()),
+            rmcp::model::RequestId::Number(9),
+        );
+
+        let internal = rmcp_client_tx_to_internal(rmcp_msg)
+            .expect("expected conversion from rmcp client tx to internal JSON-RPC");
+
+        match internal {
+            JsonRpcMessage::Response(resp) => {
+                assert_eq!(resp.id, serde_json::json!(9));
+                assert_eq!(resp.result, serde_json::json!({}));
+            }
+            other => panic!("expected internal response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_server_rx_roundtrip_preserves_wire_shape() {
+        let internal = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!("abc"),
+            method: "ping".to_string(),
+            params: None,
+        });
+
+        let rmcp_msg = internal_to_rmcp_server_rx(&internal)
+            .expect("expected conversion to rmcp server rx message");
+        let value = serde_json::to_value(rmcp_msg).expect("serialize rmcp message to JSON");
+        let roundtrip_internal: JsonRpcMessage =
+            serde_json::from_value(value).expect("deserialize back to internal JSON-RPC");
+
+        match roundtrip_internal {
+            JsonRpcMessage::Request(req) => {
+                assert_eq!(req.id, serde_json::json!("abc"));
+                assert_eq!(req.method, "ping");
+            }
+            other => panic!("expected internal request, got {other:?}"),
+        }
+    }
+}

--- a/src/rmcp_transport/mod.rs
+++ b/src/rmcp_transport/mod.rs
@@ -1,0 +1,13 @@
+//! RMCP integration scaffolding.
+//!
+//! This module will host adapters that bridge the existing Nostr transport
+//! implementation with rmcp services.
+
+pub mod convert;
+pub mod worker;
+
+pub use convert::{
+	internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
+	rmcp_server_tx_to_internal,
+};
+pub use worker::{NostrClientWorker, NostrServerWorker};

--- a/src/rmcp_transport/mod.rs
+++ b/src/rmcp_transport/mod.rs
@@ -9,7 +9,7 @@ pub mod worker;
 mod pipeline_tests;
 
 pub use convert::{
-	internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
-	rmcp_server_tx_to_internal,
+    internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
+    rmcp_server_tx_to_internal,
 };
 pub use worker::{NostrClientWorker, NostrServerWorker};

--- a/src/rmcp_transport/mod.rs
+++ b/src/rmcp_transport/mod.rs
@@ -1,10 +1,12 @@
 //! RMCP integration scaffolding.
 //!
-//! This module will host adapters that bridge the existing Nostr transport
-//! implementation with rmcp services.
+//! This module bridges the existing Nostr transport implementation with rmcp services.
 
 pub mod convert;
 pub mod worker;
+
+#[cfg(test)]
+mod pipeline_tests;
 
 pub use convert::{
 	internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,

--- a/src/rmcp_transport/pipeline_tests.rs
+++ b/src/rmcp_transport/pipeline_tests.rs
@@ -1,0 +1,309 @@
+//! End-to-end pipeline tests for the rmcp ↔ Nostr transport integration.
+//!
+//! These tests verify every step of the message journey without requiring a live
+//! relay connection:
+//!
+//! ```text
+//! Nostr event content (JSON string)
+//!   → serializers::nostr_event_to_mcp_message   [Layer 1: deserialise]
+//!   → internal_to_rmcp_server_rx                [Layer 2: type bridge]
+//!   → (rmcp handler processes it)               [Layer 3: rmcp dispatch – simulated]
+//!   → rmcp_server_tx_to_internal                [Layer 4: type bridge back]
+//!   → send_response (event_id correlation)      [Layer 5: route back to Nostr – mocked]
+//! ```
+
+#[cfg(all(test, feature = "rmcp"))]
+mod tests {
+    use std::collections::HashMap;
+
+    use rmcp::model::{ClientJsonRpcMessage, ClientResult, RequestId, ServerJsonRpcMessage, ServerResult};
+
+    use crate::core::serializers;
+    use crate::core::types::{JsonRpcError, JsonRpcErrorResponse, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
+    use crate::rmcp_transport::convert::{
+        internal_to_rmcp_client_rx, internal_to_rmcp_server_rx,
+        rmcp_client_tx_to_internal, rmcp_server_tx_to_internal,
+    };
+
+    // ── Layer 1: Nostr event content → JsonRpcMessage ──────────────────────
+
+    #[test]
+    fn layer1_nostr_content_to_internal_request() {
+        let content = r#"{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}"#;
+        let msg = serializers::nostr_event_to_mcp_message(content)
+            .expect("valid MCP request should parse");
+
+        assert!(msg.is_request());
+        assert_eq!(msg.method(), Some("ping"));
+        assert_eq!(msg.id(), Some(&serde_json::json!(1)));
+    }
+
+    #[test]
+    fn layer1_nostr_content_to_internal_tools_list() {
+        let content = r#"{"jsonrpc":"2.0","id":"abc","method":"tools/list","params":{}}"#;
+        let msg = serializers::nostr_event_to_mcp_message(content).unwrap();
+        assert_eq!(msg.method(), Some("tools/list"));
+        assert_eq!(msg.id(), Some(&serde_json::json!("abc")));
+    }
+
+    #[test]
+    fn layer1_nostr_content_to_internal_notification() {
+        let content = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+        let msg = serializers::nostr_event_to_mcp_message(content).unwrap();
+        assert!(!msg.is_request());
+        assert_eq!(msg.method(), Some("notifications/initialized"));
+    }
+
+    #[test]
+    fn layer1_nostr_content_invalid_json_returns_none() {
+        assert!(serializers::nostr_event_to_mcp_message("not json").is_none());
+    }
+
+    #[test]
+    fn layer1_nostr_event_to_mcp_message_no_version_check() {
+        // DESIGN NOTE: nostr_event_to_mcp_message uses raw serde deserialization —
+        // it does NOT reject invalid jsonrpc versions.  Version enforcement happens
+        // one layer up in base.rs via validate_message(), which IS tested separately
+        // in core::validation::tests::test_invalid_version and
+        // transport::base::tests::test_convert_event_to_mcp_invalid_jsonrpc_version.
+        //
+        // A message with jsonrpc "1.0" will parse successfully at the serializer
+        // layer because JsonRpcRequest accepts any String for the jsonrpc field.
+        let content = r#"{"jsonrpc":"1.0","id":1,"method":"ping"}"#;
+        // It parses — the struct captures jsonrpc as a plain String.
+        let msg = serializers::nostr_event_to_mcp_message(content);
+        // We don't assert None here; rejection happens in base.rs, not here.
+        // What we DO assert: if it parsed, the method and id are intact.
+        if let Some(msg) = msg {
+            assert_eq!(msg.method(), Some("ping"));
+        }
+        // The real rejection path is covered by:
+        //   transport::base::tests::test_convert_event_to_mcp_invalid_jsonrpc_version
+    }
+
+    // ── Layer 2: JsonRpcMessage → rmcp RxJsonRpcMessage (server) ───────────
+
+    #[test]
+    fn layer2_internal_request_converts_to_rmcp_server_rx() {
+        let msg = make_request("ping", serde_json::json!(1), None);
+        let rmcp = internal_to_rmcp_server_rx(&msg).expect("ping should convert");
+
+        let v = serde_json::to_value(&rmcp).unwrap();
+        assert_eq!(v["method"], "ping");
+        assert_eq!(v["id"], serde_json::json!(1));
+        assert_eq!(v["jsonrpc"], "2.0");
+    }
+
+    #[test]
+    fn layer2_string_id_preserved_through_bridge() {
+        let msg = make_request("tools/list", serde_json::json!("req-xyz"), None);
+        let rmcp = internal_to_rmcp_server_rx(&msg).unwrap();
+
+        let v = serde_json::to_value(&rmcp).unwrap();
+        assert_eq!(v["id"], serde_json::json!("req-xyz"));
+    }
+
+    #[test]
+    fn layer2_notification_converts_to_rmcp_server_rx() {
+        let msg = JsonRpcMessage::Notification(JsonRpcNotification {
+            jsonrpc: "2.0".to_string(),
+            method: "notifications/initialized".to_string(),
+            params: None,
+        });
+        let rmcp = internal_to_rmcp_server_rx(&msg)
+            .expect("initialized notification should convert");
+        let v = serde_json::to_value(&rmcp).unwrap();
+        assert_eq!(v["method"], "notifications/initialized");
+    }
+
+    #[test]
+    fn layer2_tools_list_with_params_converts() {
+        let msg = make_request(
+            "tools/list",
+            serde_json::json!(7),
+            Some(serde_json::json!({"cursor": "next-page"})),
+        );
+        let rmcp = internal_to_rmcp_server_rx(&msg).unwrap();
+        let v = serde_json::to_value(&rmcp).unwrap();
+        assert_eq!(v["method"], "tools/list");
+        assert_eq!(v["params"]["cursor"], "next-page");
+    }
+
+    // ── Layer 3+4: Simulated handler → rmcp response → internal ────────────
+
+    #[test]
+    fn layer4_rmcp_ping_response_roundtrip_number_id() {
+        // Simulate rmcp handler producing a ping response
+        let rmcp_response = ServerJsonRpcMessage::response(
+            ServerResult::empty(()),
+            RequestId::Number(42),
+        );
+        let internal = rmcp_server_tx_to_internal(rmcp_response)
+            .expect("ping response should convert back");
+
+        match internal {
+            JsonRpcMessage::Response(r) => {
+                assert_eq!(r.id, serde_json::json!(42));
+                assert_eq!(r.jsonrpc, "2.0");
+            }
+            other => panic!("expected Response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn layer4_rmcp_ping_response_roundtrip_string_id() {
+        let rmcp_response = ServerJsonRpcMessage::response(
+            ServerResult::empty(()),
+            RequestId::String(std::sync::Arc::from("req-xyz")),
+        );
+        let internal = rmcp_server_tx_to_internal(rmcp_response).unwrap();
+
+        match internal {
+            JsonRpcMessage::Response(r) => {
+                assert_eq!(r.id, serde_json::json!("req-xyz"));
+            }
+            other => panic!("expected Response, got {other:?}"),
+        }
+    }
+
+    // ── Full roundtrip: internal → rmcp → internal ──────────────────────────
+
+    #[test]
+    fn full_server_roundtrip_request_id_preserved() {
+        // Layer 2: convert incoming request to rmcp
+        let original = make_request("ping", serde_json::json!(99), None);
+        let rmcp_rx = internal_to_rmcp_server_rx(&original).unwrap();
+
+        // Extract the ID that rmcp sees
+        let rmcp_value = serde_json::to_value(&rmcp_rx).unwrap();
+        let id_seen_by_rmcp = rmcp_value["id"].clone();
+        assert_eq!(id_seen_by_rmcp, serde_json::json!(99));
+
+        // Layer 4: rmcp produces a response with the same ID echoed back
+        let rmcp_tx = ServerJsonRpcMessage::response(
+            ServerResult::empty(()),
+            RequestId::Number(99),
+        );
+        let response = rmcp_server_tx_to_internal(rmcp_tx).unwrap();
+
+        // The response ID must equal the original request ID
+        assert_eq!(response.id(), Some(&serde_json::json!(99)));
+    }
+
+    #[test]
+    fn full_client_roundtrip_response_id_preserved() {
+        // Client side: rmcp produces an outbound request
+        let rmcp_tx = ClientJsonRpcMessage::response(
+            ClientResult::empty(()),
+            RequestId::Number(7),
+        );
+        let internal = rmcp_client_tx_to_internal(rmcp_tx).unwrap();
+        assert_eq!(internal.id(), Some(&serde_json::json!(7)));
+
+        // And an incoming server response converts to rmcp correctly
+        let incoming_response = JsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(7),
+            result: serde_json::json!({"tools": []}),
+        });
+        let rmcp_rx = internal_to_rmcp_client_rx(&incoming_response).unwrap();
+        let v = serde_json::to_value(&rmcp_rx).unwrap();
+        assert_eq!(v["id"], serde_json::json!(7));
+        assert_eq!(v["result"]["tools"], serde_json::json!([]));
+    }
+
+    // ── Layer 5: ID correlation map logic (mirrors NostrServerWorker) ────────
+
+    #[test]
+    fn layer5_worker_correlation_map_number_id() {
+        let mut request_id_to_event_id: HashMap<String, String> = HashMap::new();
+        let fake_event_id = "aaaaaa".to_string();
+
+        // Step 1: incoming request arrives — worker stores req_id → event_id
+        let req = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(42),
+            method: "tools/list".to_string(),
+            params: None,
+        });
+
+        if let JsonRpcMessage::Request(ref r) = req {
+            let key = serde_json::to_string(&r.id).unwrap();
+            request_id_to_event_id.insert(key, fake_event_id.clone());
+        }
+
+        // Step 2: rmcp response comes back with id=42
+        let response = JsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(42),
+            result: serde_json::json!({}),
+        });
+
+        // Step 3: worker looks up the event_id to call send_response
+        if let JsonRpcMessage::Response(ref r) = response {
+            let key = serde_json::to_string(&r.id).unwrap();
+            let found = request_id_to_event_id.remove(&key);
+            assert_eq!(found, Some(fake_event_id));
+        } else {
+            panic!("expected Response");
+        }
+
+        // Map should be empty after handling
+        assert!(request_id_to_event_id.is_empty());
+    }
+
+    #[test]
+    fn layer5_worker_correlation_map_string_id() {
+        let mut request_id_to_event_id: HashMap<String, String> = HashMap::new();
+        let fake_event_id = "bbbbbb".to_string();
+
+        // String IDs serialize with surrounding quotes: "\"req-abc\""
+        let req_id = serde_json::json!("req-abc");
+        let key = serde_json::to_string(&req_id).unwrap();
+        request_id_to_event_id.insert(key.clone(), fake_event_id.clone());
+
+        // The response ID serializes identically
+        let resp_id = serde_json::json!("req-abc");
+        let resp_key = serde_json::to_string(&resp_id).unwrap();
+
+        // Key derived from response ID must match the one stored from request ID
+        assert_eq!(key, resp_key);
+        assert_eq!(request_id_to_event_id.remove(&resp_key), Some(fake_event_id));
+    }
+
+    #[test]
+    fn layer5_error_response_correlation_works() {
+        let mut map: HashMap<String, String> = HashMap::new();
+        map.insert(serde_json::to_string(&serde_json::json!(5)).unwrap(), "evt5".to_string());
+
+        let error_response = JsonRpcMessage::ErrorResponse(JsonRpcErrorResponse {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(5),
+            error: JsonRpcError {
+                code: -32601,
+                message: "Method not found".to_string(),
+                data: None,
+            },
+        });
+
+        if let JsonRpcMessage::ErrorResponse(ref r) = error_response {
+            let key = serde_json::to_string(&r.id).unwrap();
+            assert_eq!(map.remove(&key), Some("evt5".to_string()));
+        }
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────────────
+
+    fn make_request(
+        method: &str,
+        id: serde_json::Value,
+        params: Option<serde_json::Value>,
+    ) -> JsonRpcMessage {
+        JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id,
+            method: method.to_string(),
+            params,
+        })
+    }
+}

--- a/src/rmcp_transport/pipeline_tests.rs
+++ b/src/rmcp_transport/pipeline_tests.rs
@@ -16,13 +16,18 @@
 mod tests {
     use std::collections::HashMap;
 
-    use rmcp::model::{ClientJsonRpcMessage, ClientResult, RequestId, ServerJsonRpcMessage, ServerResult};
+    use rmcp::model::{
+        ClientJsonRpcMessage, ClientResult, RequestId, ServerJsonRpcMessage, ServerResult,
+    };
 
     use crate::core::serializers;
-    use crate::core::types::{JsonRpcError, JsonRpcErrorResponse, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
+    use crate::core::types::{
+        JsonRpcError, JsonRpcErrorResponse, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
+        JsonRpcResponse,
+    };
     use crate::rmcp_transport::convert::{
-        internal_to_rmcp_client_rx, internal_to_rmcp_server_rx,
-        rmcp_client_tx_to_internal, rmcp_server_tx_to_internal,
+        internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
+        rmcp_server_tx_to_internal,
     };
 
     // ── Layer 1: Nostr event content → JsonRpcMessage ──────────────────────
@@ -110,8 +115,8 @@ mod tests {
             method: "notifications/initialized".to_string(),
             params: None,
         });
-        let rmcp = internal_to_rmcp_server_rx(&msg)
-            .expect("initialized notification should convert");
+        let rmcp =
+            internal_to_rmcp_server_rx(&msg).expect("initialized notification should convert");
         let v = serde_json::to_value(&rmcp).unwrap();
         assert_eq!(v["method"], "notifications/initialized");
     }
@@ -134,12 +139,10 @@ mod tests {
     #[test]
     fn layer4_rmcp_ping_response_roundtrip_number_id() {
         // Simulate rmcp handler producing a ping response
-        let rmcp_response = ServerJsonRpcMessage::response(
-            ServerResult::empty(()),
-            RequestId::Number(42),
-        );
-        let internal = rmcp_server_tx_to_internal(rmcp_response)
-            .expect("ping response should convert back");
+        let rmcp_response =
+            ServerJsonRpcMessage::response(ServerResult::empty(()), RequestId::Number(42));
+        let internal =
+            rmcp_server_tx_to_internal(rmcp_response).expect("ping response should convert back");
 
         match internal {
             JsonRpcMessage::Response(r) => {
@@ -180,10 +183,8 @@ mod tests {
         assert_eq!(id_seen_by_rmcp, serde_json::json!(99));
 
         // Layer 4: rmcp produces a response with the same ID echoed back
-        let rmcp_tx = ServerJsonRpcMessage::response(
-            ServerResult::empty(()),
-            RequestId::Number(99),
-        );
+        let rmcp_tx =
+            ServerJsonRpcMessage::response(ServerResult::empty(()), RequestId::Number(99));
         let response = rmcp_server_tx_to_internal(rmcp_tx).unwrap();
 
         // The response ID must equal the original request ID
@@ -193,10 +194,7 @@ mod tests {
     #[test]
     fn full_client_roundtrip_response_id_preserved() {
         // Client side: rmcp produces an outbound request
-        let rmcp_tx = ClientJsonRpcMessage::response(
-            ClientResult::empty(()),
-            RequestId::Number(7),
-        );
+        let rmcp_tx = ClientJsonRpcMessage::response(ClientResult::empty(()), RequestId::Number(7));
         let internal = rmcp_client_tx_to_internal(rmcp_tx).unwrap();
         assert_eq!(internal.id(), Some(&serde_json::json!(7)));
 
@@ -268,13 +266,19 @@ mod tests {
 
         // Key derived from response ID must match the one stored from request ID
         assert_eq!(key, resp_key);
-        assert_eq!(request_id_to_event_id.remove(&resp_key), Some(fake_event_id));
+        assert_eq!(
+            request_id_to_event_id.remove(&resp_key),
+            Some(fake_event_id)
+        );
     }
 
     #[test]
     fn layer5_error_response_correlation_works() {
         let mut map: HashMap<String, String> = HashMap::new();
-        map.insert(serde_json::to_string(&serde_json::json!(5)).unwrap(), "evt5".to_string());
+        map.insert(
+            serde_json::to_string(&serde_json::json!(5)).unwrap(),
+            "evt5".to_string(),
+        );
 
         let error_response = JsonRpcMessage::ErrorResponse(JsonRpcErrorResponse {
             jsonrpc: "2.0".to_string(),

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -1,0 +1,246 @@
+//! rmcp worker adapters.
+//!
+//! This file defines wrapper types that bind existing ContextVM Nostr
+//! transports to rmcp's worker abstraction.
+
+use crate::core::error::Result;
+use crate::core::types::JsonRpcMessage;
+use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
+use crate::transport::server::{NostrServerTransport, NostrServerTransportConfig};
+use rmcp::transport::worker::{Worker, WorkerContext, WorkerQuitReason};
+
+use super::convert::{
+	internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
+	rmcp_server_tx_to_internal,
+};
+
+/// rmcp server worker wrapper for ContextVM Nostr server transport.
+pub struct NostrServerWorker {
+	transport: NostrServerTransport,
+}
+
+impl NostrServerWorker {
+	/// Create a new server worker from existing server transport config.
+	pub async fn new<T>(signer: T, config: NostrServerTransportConfig) -> Result<Self>
+	where
+		T: nostr_sdk::prelude::IntoNostrSigner,
+	{
+		let transport = NostrServerTransport::new(signer, config).await?;
+		Ok(Self { transport })
+	}
+
+	/// Access the wrapped transport.
+	pub fn transport(&self) -> &NostrServerTransport {
+		&self.transport
+	}
+}
+
+impl Worker for NostrServerWorker {
+	type Error = crate::core::error::Error;
+	type Role = rmcp::RoleServer;
+
+	fn err_closed() -> Self::Error {
+		Self::Error::Transport("rmcp worker channel closed".to_string())
+	}
+
+	fn err_join(e: tokio::task::JoinError) -> Self::Error {
+		Self::Error::Other(format!("rmcp worker join error: {e}"))
+	}
+
+	async fn run(
+		mut self,
+		mut context: WorkerContext<Self>,
+	) -> std::result::Result<(), WorkerQuitReason<Self::Error>> {
+		self.transport
+			.start()
+			.await
+			.map_err(WorkerQuitReason::fatal_context("starting server transport"))?;
+
+		let mut rx = self.transport.take_message_receiver().ok_or_else(|| {
+			WorkerQuitReason::fatal(
+				Self::Error::Other("server message receiver already taken".to_string()),
+				"taking server message receiver",
+			)
+		})?;
+
+		let cancellation_token = context.cancellation_token.clone();
+
+		let quit_reason = loop {
+			tokio::select! {
+				_ = cancellation_token.cancelled() => {
+					break WorkerQuitReason::Cancelled;
+				}
+				incoming = rx.recv() => {
+					let Some(mut incoming) = incoming else {
+						break WorkerQuitReason::TransportClosed;
+					};
+
+					// Use event_id as internal request id to keep response routing deterministic.
+					if let JsonRpcMessage::Request(ref mut req) = incoming.message {
+						req.id = serde_json::json!(incoming.event_id.clone());
+					}
+
+					if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&incoming.message) {
+						if let Err(reason) = context.send_to_handler(rmcp_msg).await {
+							break reason;
+						}
+					} else {
+						tracing::warn!("Failed to convert incoming server-side message to rmcp format");
+					}
+				}
+				outbound = context.recv_from_handler() => {
+					let outbound = match outbound {
+						Ok(outbound) => outbound,
+						Err(reason) => break reason,
+					};
+
+					let result = if let Some(internal_msg) = rmcp_server_tx_to_internal(outbound.message) {
+						self.forward_server_internal(internal_msg).await
+					} else {
+						Err(Self::Error::Validation(
+							"failed converting rmcp server message to internal JSON-RPC".to_string(),
+						))
+					};
+
+					let _ = outbound.responder.send(result);
+				}
+			}
+		};
+
+		if let Err(e) = self.transport.close().await {
+			tracing::warn!("Failed to close server transport cleanly: {e}");
+		}
+
+		Err(quit_reason)
+	}
+}
+
+/// rmcp client worker wrapper for ContextVM Nostr client transport.
+pub struct NostrClientWorker {
+	transport: NostrClientTransport,
+}
+
+impl NostrClientWorker {
+	/// Create a new client worker from existing client transport config.
+	pub async fn new<T>(signer: T, config: NostrClientTransportConfig) -> Result<Self>
+	where
+		T: nostr_sdk::prelude::IntoNostrSigner,
+	{
+		let transport = NostrClientTransport::new(signer, config).await?;
+		Ok(Self { transport })
+	}
+
+	/// Access the wrapped transport.
+	pub fn transport(&self) -> &NostrClientTransport {
+		&self.transport
+	}
+}
+
+impl Worker for NostrClientWorker {
+	type Error = crate::core::error::Error;
+	type Role = rmcp::RoleClient;
+
+	fn err_closed() -> Self::Error {
+		Self::Error::Transport("rmcp worker channel closed".to_string())
+	}
+
+	fn err_join(e: tokio::task::JoinError) -> Self::Error {
+		Self::Error::Other(format!("rmcp worker join error: {e}"))
+	}
+
+	async fn run(
+		mut self,
+		mut context: WorkerContext<Self>,
+	) -> std::result::Result<(), WorkerQuitReason<Self::Error>> {
+		self.transport
+			.start()
+			.await
+			.map_err(WorkerQuitReason::fatal_context("starting client transport"))?;
+
+		let mut rx = self.transport.take_message_receiver().ok_or_else(|| {
+			WorkerQuitReason::fatal(
+				Self::Error::Other("client message receiver already taken".to_string()),
+				"taking client message receiver",
+			)
+		})?;
+
+		let cancellation_token = context.cancellation_token.clone();
+
+		let quit_reason = loop {
+			tokio::select! {
+				_ = cancellation_token.cancelled() => {
+					break WorkerQuitReason::Cancelled;
+				}
+				incoming = rx.recv() => {
+					let Some(incoming) = incoming else {
+						break WorkerQuitReason::TransportClosed;
+					};
+
+					if let Some(rmcp_msg) = internal_to_rmcp_client_rx(&incoming) {
+						if let Err(reason) = context.send_to_handler(rmcp_msg).await {
+							break reason;
+						}
+					} else {
+						tracing::warn!("Failed to convert incoming client-side message to rmcp format");
+					}
+				}
+				outbound = context.recv_from_handler() => {
+					let outbound = match outbound {
+						Ok(outbound) => outbound,
+						Err(reason) => break reason,
+					};
+
+					let result = if let Some(internal_msg) = rmcp_client_tx_to_internal(outbound.message) {
+						self.transport.send(&internal_msg).await
+					} else {
+						Err(Self::Error::Validation(
+							"failed converting rmcp client message to internal JSON-RPC".to_string(),
+						))
+					};
+
+					let _ = outbound.responder.send(result);
+				}
+			}
+		};
+
+		if let Err(e) = self.transport.close().await {
+			tracing::warn!("Failed to close client transport cleanly: {e}");
+		}
+
+		Err(quit_reason)
+	}
+}
+
+impl NostrServerWorker {
+	async fn forward_server_internal(&self, message: JsonRpcMessage) -> Result<()> {
+		match message {
+			JsonRpcMessage::Response(resp) => {
+				let event_id = resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+					crate::core::error::Error::Validation(
+						"rmcp server response id must be a string event id".to_string(),
+					)
+				})?;
+				self.transport
+					.send_response(&event_id, JsonRpcMessage::Response(resp))
+					.await
+			}
+			JsonRpcMessage::ErrorResponse(resp) => {
+				let event_id = resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+					crate::core::error::Error::Validation(
+						"rmcp server error response id must be a string event id".to_string(),
+					)
+				})?;
+				self.transport
+					.send_response(&event_id, JsonRpcMessage::ErrorResponse(resp))
+					.await
+			}
+			JsonRpcMessage::Notification(notification) => {
+				let message = JsonRpcMessage::Notification(notification);
+				self.transport.broadcast_notification(&message).await
+			}
+			JsonRpcMessage::Request(_) => Err(crate::core::error::Error::Validation(
+				"rmcp server worker cannot forward outbound request messages".to_string(),
+			)),
+		}
+	}
+}

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use crate::core::error::Result;
 use crate::core::types::JsonRpcMessage;
+use crate::util::logger;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use crate::transport::server::{NostrServerTransport, NostrServerTransportConfig};
 use rmcp::transport::worker::{Worker, WorkerContext, WorkerQuitReason};

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -3,6 +3,8 @@
 //! This file defines wrapper types that bind existing ContextVM Nostr
 //! transports to rmcp's worker abstraction.
 
+use std::collections::HashMap;
+
 use crate::core::error::Result;
 use crate::core::types::JsonRpcMessage;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
@@ -17,6 +19,10 @@ use super::convert::{
 /// rmcp server worker wrapper for ContextVM Nostr server transport.
 pub struct NostrServerWorker {
 	transport: NostrServerTransport,
+	// rmcp service instance is single-peer. Keep one active client per worker.
+	active_client_pubkey: Option<String>,
+	// Maps request id (serialized JSON value) -> incoming Nostr event id.
+	request_id_to_event_id: HashMap<String, String>,
 }
 
 impl NostrServerWorker {
@@ -26,7 +32,11 @@ impl NostrServerWorker {
 		T: nostr_sdk::prelude::IntoNostrSigner,
 	{
 		let transport = NostrServerTransport::new(signer, config).await?;
-		Ok(Self { transport })
+		Ok(Self {
+			transport,
+			active_client_pubkey: None,
+			request_id_to_event_id: HashMap::new(),
+		})
 	}
 
 	/// Access the wrapped transport.
@@ -71,16 +81,45 @@ impl Worker for NostrServerWorker {
 					break WorkerQuitReason::Cancelled;
 				}
 				incoming = rx.recv() => {
-					let Some(mut incoming) = incoming else {
+					let Some(incoming) = incoming else {
 						break WorkerQuitReason::TransportClosed;
 					};
 
-					// Use event_id as internal request id to keep response routing deterministic.
-					if let JsonRpcMessage::Request(ref mut req) = incoming.message {
-						req.id = serde_json::json!(incoming.event_id.clone());
+					let crate::transport::server::IncomingRequest {
+						message,
+						client_pubkey,
+						event_id,
+						..
+					} = incoming;
+
+					match &self.active_client_pubkey {
+						Some(active) if active != &client_pubkey => {
+							tracing::warn!(
+								active_client = %active,
+								ignored_client = %client_pubkey,
+								"Ignoring message from second client: rmcp server worker currently supports one active client per worker"
+							);
+							continue;
+						}
+						None => {
+							tracing::info!(client_pubkey = %client_pubkey, "Binding rmcp server worker to first client session");
+							self.active_client_pubkey = Some(client_pubkey.clone());
+						}
+						_ => {}
 					}
 
-					if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&incoming.message) {
+					if let JsonRpcMessage::Request(req) = &message {
+						match serde_json::to_string(&req.id) {
+							Ok(request_key) => {
+								self.request_id_to_event_id.insert(request_key, event_id);
+							}
+							Err(e) => {
+								tracing::warn!("Failed to serialize request id for correlation map: {e}");
+							}
+						}
+					}
+
+					if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&message) {
 						if let Err(reason) = context.send_to_handler(rmcp_msg).await {
 							break reason;
 						}
@@ -212,35 +251,71 @@ impl Worker for NostrClientWorker {
 }
 
 impl NostrServerWorker {
-	async fn forward_server_internal(&self, message: JsonRpcMessage) -> Result<()> {
+	async fn forward_server_internal(&mut self, message: JsonRpcMessage) -> Result<()> {
 		match message {
 			JsonRpcMessage::Response(resp) => {
-				let event_id = resp.id.as_str().map(str::to_owned).ok_or_else(|| {
-					crate::core::error::Error::Validation(
-						"rmcp server response id must be a string event id".to_string(),
-					)
+				let request_key = serde_json::to_string(&resp.id).map_err(|e| {
+					crate::core::error::Error::Validation(format!(
+						"failed to serialize rmcp response id for correlation lookup: {e}"
+					))
 				})?;
+
+				let event_id = if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
+					event_id
+				} else {
+					resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+						crate::core::error::Error::Validation(
+							"rmcp server response id has no known correlation mapping and is not a string event id"
+								.to_string(),
+						)
+					})?
+				};
+
 				self.transport
 					.send_response(&event_id, JsonRpcMessage::Response(resp))
 					.await
 			}
 			JsonRpcMessage::ErrorResponse(resp) => {
-				let event_id = resp.id.as_str().map(str::to_owned).ok_or_else(|| {
-					crate::core::error::Error::Validation(
-						"rmcp server error response id must be a string event id".to_string(),
-					)
+				let request_key = serde_json::to_string(&resp.id).map_err(|e| {
+					crate::core::error::Error::Validation(format!(
+						"failed to serialize rmcp error response id for correlation lookup: {e}"
+					))
 				})?;
+
+				let event_id = if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
+					event_id
+				} else {
+					resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+						crate::core::error::Error::Validation(
+							"rmcp server error response id has no known correlation mapping and is not a string event id"
+								.to_string(),
+						)
+					})?
+				};
+
 				self.transport
 					.send_response(&event_id, JsonRpcMessage::ErrorResponse(resp))
 					.await
 			}
 			JsonRpcMessage::Notification(notification) => {
+				let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
+					crate::core::error::Error::Validation(
+						"cannot forward rmcp server notification: no active client bound"
+							.to_string(),
+					)
+				})?;
 				let message = JsonRpcMessage::Notification(notification);
-				self.transport.broadcast_notification(&message).await
+				self.transport.send_notification(target, &message, None).await
 			}
-			JsonRpcMessage::Request(_) => Err(crate::core::error::Error::Validation(
-				"rmcp server worker cannot forward outbound request messages".to_string(),
-			)),
+			JsonRpcMessage::Request(request) => {
+				let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
+					crate::core::error::Error::Validation(
+						"cannot forward rmcp server request: no active client bound".to_string(),
+					)
+				})?;
+				let message = JsonRpcMessage::Request(request);
+				self.transport.send_notification(target, &message, None).await
+			}
 		}
 	}
 }

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -12,310 +12,316 @@ use crate::transport::server::{NostrServerTransport, NostrServerTransportConfig}
 use rmcp::transport::worker::{Worker, WorkerContext, WorkerQuitReason};
 
 use super::convert::{
-	internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
-	rmcp_server_tx_to_internal,
+    internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
+    rmcp_server_tx_to_internal,
 };
 
 /// rmcp server worker wrapper for ContextVM Nostr server transport.
 pub struct NostrServerWorker {
-	transport: NostrServerTransport,
-	// rmcp service instance is single-peer. Keep one active client per worker.
-	active_client_pubkey: Option<String>,
-	// Maps request id (serialized JSON value) -> incoming Nostr event id.
-	request_id_to_event_id: HashMap<String, String>,
+    transport: NostrServerTransport,
+    // rmcp service instance is single-peer. Keep one active client per worker.
+    active_client_pubkey: Option<String>,
+    // Maps request id (serialized JSON value) -> incoming Nostr event id.
+    request_id_to_event_id: HashMap<String, String>,
 }
 
 impl NostrServerWorker {
-	/// Create a new server worker from existing server transport config.
-	pub async fn new<T>(signer: T, config: NostrServerTransportConfig) -> Result<Self>
-	where
-		T: nostr_sdk::prelude::IntoNostrSigner,
-	{
-		let transport = NostrServerTransport::new(signer, config).await?;
-		Ok(Self {
-			transport,
-			active_client_pubkey: None,
-			request_id_to_event_id: HashMap::new(),
-		})
-	}
+    /// Create a new server worker from existing server transport config.
+    pub async fn new<T>(signer: T, config: NostrServerTransportConfig) -> Result<Self>
+    where
+        T: nostr_sdk::prelude::IntoNostrSigner,
+    {
+        let transport = NostrServerTransport::new(signer, config).await?;
+        Ok(Self {
+            transport,
+            active_client_pubkey: None,
+            request_id_to_event_id: HashMap::new(),
+        })
+    }
 
-	/// Access the wrapped transport.
-	pub fn transport(&self) -> &NostrServerTransport {
-		&self.transport
-	}
+    /// Access the wrapped transport.
+    pub fn transport(&self) -> &NostrServerTransport {
+        &self.transport
+    }
 }
 
 impl Worker for NostrServerWorker {
-	type Error = crate::core::error::Error;
-	type Role = rmcp::RoleServer;
+    type Error = crate::core::error::Error;
+    type Role = rmcp::RoleServer;
 
-	fn err_closed() -> Self::Error {
-		Self::Error::Transport("rmcp worker channel closed".to_string())
-	}
+    fn err_closed() -> Self::Error {
+        Self::Error::Transport("rmcp worker channel closed".to_string())
+    }
 
-	fn err_join(e: tokio::task::JoinError) -> Self::Error {
-		Self::Error::Other(format!("rmcp worker join error: {e}"))
-	}
+    fn err_join(e: tokio::task::JoinError) -> Self::Error {
+        Self::Error::Other(format!("rmcp worker join error: {e}"))
+    }
 
-	async fn run(
-		mut self,
-		mut context: WorkerContext<Self>,
-	) -> std::result::Result<(), WorkerQuitReason<Self::Error>> {
-		self.transport
-			.start()
-			.await
-			.map_err(WorkerQuitReason::fatal_context("starting server transport"))?;
+    async fn run(
+        mut self,
+        mut context: WorkerContext<Self>,
+    ) -> std::result::Result<(), WorkerQuitReason<Self::Error>> {
+        self.transport
+            .start()
+            .await
+            .map_err(WorkerQuitReason::fatal_context("starting server transport"))?;
 
-		let mut rx = self.transport.take_message_receiver().ok_or_else(|| {
-			WorkerQuitReason::fatal(
-				Self::Error::Other("server message receiver already taken".to_string()),
-				"taking server message receiver",
-			)
-		})?;
+        let mut rx = self.transport.take_message_receiver().ok_or_else(|| {
+            WorkerQuitReason::fatal(
+                Self::Error::Other("server message receiver already taken".to_string()),
+                "taking server message receiver",
+            )
+        })?;
 
-		let cancellation_token = context.cancellation_token.clone();
+        let cancellation_token = context.cancellation_token.clone();
 
-		let quit_reason = loop {
-			tokio::select! {
-				_ = cancellation_token.cancelled() => {
-					break WorkerQuitReason::Cancelled;
-				}
-				incoming = rx.recv() => {
-					let Some(incoming) = incoming else {
-						break WorkerQuitReason::TransportClosed;
-					};
+        let quit_reason = loop {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    break WorkerQuitReason::Cancelled;
+                }
+                incoming = rx.recv() => {
+                    let Some(incoming) = incoming else {
+                        break WorkerQuitReason::TransportClosed;
+                    };
 
-					let crate::transport::server::IncomingRequest {
-						message,
-						client_pubkey,
-						event_id,
-						..
-					} = incoming;
+                    let crate::transport::server::IncomingRequest {
+                        message,
+                        client_pubkey,
+                        event_id,
+                        ..
+                    } = incoming;
 
-					match &self.active_client_pubkey {
-						Some(active) if active != &client_pubkey => {
-							tracing::warn!(
-								active_client = %active,
-								ignored_client = %client_pubkey,
-								"Ignoring message from second client: rmcp server worker currently supports one active client per worker"
-							);
-							continue;
-						}
-						None => {
-							tracing::info!(client_pubkey = %client_pubkey, "Binding rmcp server worker to first client session");
-							self.active_client_pubkey = Some(client_pubkey.clone());
-						}
-						_ => {}
-					}
+                    match &self.active_client_pubkey {
+                        Some(active) if active != &client_pubkey => {
+                            tracing::warn!(
+                                active_client = %active,
+                                ignored_client = %client_pubkey,
+                                "Ignoring message from second client: rmcp server worker currently supports one active client per worker"
+                            );
+                            continue;
+                        }
+                        None => {
+                            tracing::info!(client_pubkey = %client_pubkey, "Binding rmcp server worker to first client session");
+                            self.active_client_pubkey = Some(client_pubkey.clone());
+                        }
+                        _ => {}
+                    }
 
-					if let JsonRpcMessage::Request(req) = &message {
-						match serde_json::to_string(&req.id) {
-							Ok(request_key) => {
-								self.request_id_to_event_id.insert(request_key, event_id);
-							}
-							Err(e) => {
-								tracing::warn!("Failed to serialize request id for correlation map: {e}");
-							}
-						}
-					}
+                    if let JsonRpcMessage::Request(req) = &message {
+                        match serde_json::to_string(&req.id) {
+                            Ok(request_key) => {
+                                self.request_id_to_event_id.insert(request_key, event_id);
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to serialize request id for correlation map: {e}");
+                            }
+                        }
+                    }
 
-					if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&message) {
-						if let Err(reason) = context.send_to_handler(rmcp_msg).await {
-							break reason;
-						}
-					} else {
-						tracing::warn!("Failed to convert incoming server-side message to rmcp format");
-					}
-				}
-				outbound = context.recv_from_handler() => {
-					let outbound = match outbound {
-						Ok(outbound) => outbound,
-						Err(reason) => break reason,
-					};
+                    if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&message) {
+                        if let Err(reason) = context.send_to_handler(rmcp_msg).await {
+                            break reason;
+                        }
+                    } else {
+                        tracing::warn!("Failed to convert incoming server-side message to rmcp format");
+                    }
+                }
+                outbound = context.recv_from_handler() => {
+                    let outbound = match outbound {
+                        Ok(outbound) => outbound,
+                        Err(reason) => break reason,
+                    };
 
-					let result = if let Some(internal_msg) = rmcp_server_tx_to_internal(outbound.message) {
-						self.forward_server_internal(internal_msg).await
-					} else {
-						Err(Self::Error::Validation(
-							"failed converting rmcp server message to internal JSON-RPC".to_string(),
-						))
-					};
+                    let result = if let Some(internal_msg) = rmcp_server_tx_to_internal(outbound.message) {
+                        self.forward_server_internal(internal_msg).await
+                    } else {
+                        Err(Self::Error::Validation(
+                            "failed converting rmcp server message to internal JSON-RPC".to_string(),
+                        ))
+                    };
 
-					let _ = outbound.responder.send(result);
-				}
-			}
-		};
+                    let _ = outbound.responder.send(result);
+                }
+            }
+        };
 
-		if let Err(e) = self.transport.close().await {
-			tracing::warn!("Failed to close server transport cleanly: {e}");
-		}
+        if let Err(e) = self.transport.close().await {
+            tracing::warn!("Failed to close server transport cleanly: {e}");
+        }
 
-		Err(quit_reason)
-	}
+        Err(quit_reason)
+    }
 }
 
 /// rmcp client worker wrapper for ContextVM Nostr client transport.
 pub struct NostrClientWorker {
-	transport: NostrClientTransport,
+    transport: NostrClientTransport,
 }
 
 impl NostrClientWorker {
-	/// Create a new client worker from existing client transport config.
-	pub async fn new<T>(signer: T, config: NostrClientTransportConfig) -> Result<Self>
-	where
-		T: nostr_sdk::prelude::IntoNostrSigner,
-	{
-		let transport = NostrClientTransport::new(signer, config).await?;
-		Ok(Self { transport })
-	}
+    /// Create a new client worker from existing client transport config.
+    pub async fn new<T>(signer: T, config: NostrClientTransportConfig) -> Result<Self>
+    where
+        T: nostr_sdk::prelude::IntoNostrSigner,
+    {
+        let transport = NostrClientTransport::new(signer, config).await?;
+        Ok(Self { transport })
+    }
 
-	/// Access the wrapped transport.
-	pub fn transport(&self) -> &NostrClientTransport {
-		&self.transport
-	}
+    /// Access the wrapped transport.
+    pub fn transport(&self) -> &NostrClientTransport {
+        &self.transport
+    }
 }
 
 impl Worker for NostrClientWorker {
-	type Error = crate::core::error::Error;
-	type Role = rmcp::RoleClient;
+    type Error = crate::core::error::Error;
+    type Role = rmcp::RoleClient;
 
-	fn err_closed() -> Self::Error {
-		Self::Error::Transport("rmcp worker channel closed".to_string())
-	}
+    fn err_closed() -> Self::Error {
+        Self::Error::Transport("rmcp worker channel closed".to_string())
+    }
 
-	fn err_join(e: tokio::task::JoinError) -> Self::Error {
-		Self::Error::Other(format!("rmcp worker join error: {e}"))
-	}
+    fn err_join(e: tokio::task::JoinError) -> Self::Error {
+        Self::Error::Other(format!("rmcp worker join error: {e}"))
+    }
 
-	async fn run(
-		mut self,
-		mut context: WorkerContext<Self>,
-	) -> std::result::Result<(), WorkerQuitReason<Self::Error>> {
-		self.transport
-			.start()
-			.await
-			.map_err(WorkerQuitReason::fatal_context("starting client transport"))?;
+    async fn run(
+        mut self,
+        mut context: WorkerContext<Self>,
+    ) -> std::result::Result<(), WorkerQuitReason<Self::Error>> {
+        self.transport
+            .start()
+            .await
+            .map_err(WorkerQuitReason::fatal_context("starting client transport"))?;
 
-		let mut rx = self.transport.take_message_receiver().ok_or_else(|| {
-			WorkerQuitReason::fatal(
-				Self::Error::Other("client message receiver already taken".to_string()),
-				"taking client message receiver",
-			)
-		})?;
+        let mut rx = self.transport.take_message_receiver().ok_or_else(|| {
+            WorkerQuitReason::fatal(
+                Self::Error::Other("client message receiver already taken".to_string()),
+                "taking client message receiver",
+            )
+        })?;
 
-		let cancellation_token = context.cancellation_token.clone();
+        let cancellation_token = context.cancellation_token.clone();
 
-		let quit_reason = loop {
-			tokio::select! {
-				_ = cancellation_token.cancelled() => {
-					break WorkerQuitReason::Cancelled;
-				}
-				incoming = rx.recv() => {
-					let Some(incoming) = incoming else {
-						break WorkerQuitReason::TransportClosed;
-					};
+        let quit_reason = loop {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    break WorkerQuitReason::Cancelled;
+                }
+                incoming = rx.recv() => {
+                    let Some(incoming) = incoming else {
+                        break WorkerQuitReason::TransportClosed;
+                    };
 
-					if let Some(rmcp_msg) = internal_to_rmcp_client_rx(&incoming) {
-						if let Err(reason) = context.send_to_handler(rmcp_msg).await {
-							break reason;
-						}
-					} else {
-						tracing::warn!("Failed to convert incoming client-side message to rmcp format");
-					}
-				}
-				outbound = context.recv_from_handler() => {
-					let outbound = match outbound {
-						Ok(outbound) => outbound,
-						Err(reason) => break reason,
-					};
+                    if let Some(rmcp_msg) = internal_to_rmcp_client_rx(&incoming) {
+                        if let Err(reason) = context.send_to_handler(rmcp_msg).await {
+                            break reason;
+                        }
+                    } else {
+                        tracing::warn!("Failed to convert incoming client-side message to rmcp format");
+                    }
+                }
+                outbound = context.recv_from_handler() => {
+                    let outbound = match outbound {
+                        Ok(outbound) => outbound,
+                        Err(reason) => break reason,
+                    };
 
-					let result = if let Some(internal_msg) = rmcp_client_tx_to_internal(outbound.message) {
-						self.transport.send(&internal_msg).await
-					} else {
-						Err(Self::Error::Validation(
-							"failed converting rmcp client message to internal JSON-RPC".to_string(),
-						))
-					};
+                    let result = if let Some(internal_msg) = rmcp_client_tx_to_internal(outbound.message) {
+                        self.transport.send(&internal_msg).await
+                    } else {
+                        Err(Self::Error::Validation(
+                            "failed converting rmcp client message to internal JSON-RPC".to_string(),
+                        ))
+                    };
 
-					let _ = outbound.responder.send(result);
-				}
-			}
-		};
+                    let _ = outbound.responder.send(result);
+                }
+            }
+        };
 
-		if let Err(e) = self.transport.close().await {
-			tracing::warn!("Failed to close client transport cleanly: {e}");
-		}
+        if let Err(e) = self.transport.close().await {
+            tracing::warn!("Failed to close client transport cleanly: {e}");
+        }
 
-		Err(quit_reason)
-	}
+        Err(quit_reason)
+    }
 }
 
 impl NostrServerWorker {
-	async fn forward_server_internal(&mut self, message: JsonRpcMessage) -> Result<()> {
-		match message {
-			JsonRpcMessage::Response(resp) => {
-				let request_key = serde_json::to_string(&resp.id).map_err(|e| {
-					crate::core::error::Error::Validation(format!(
-						"failed to serialize rmcp response id for correlation lookup: {e}"
-					))
-				})?;
+    async fn forward_server_internal(&mut self, message: JsonRpcMessage) -> Result<()> {
+        match message {
+            JsonRpcMessage::Response(resp) => {
+                let request_key = serde_json::to_string(&resp.id).map_err(|e| {
+                    crate::core::error::Error::Validation(format!(
+                        "failed to serialize rmcp response id for correlation lookup: {e}"
+                    ))
+                })?;
 
-				let event_id = if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
-					event_id
-				} else {
-					resp.id.as_str().map(str::to_owned).ok_or_else(|| {
-						crate::core::error::Error::Validation(
+                let event_id =
+                    if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
+                        event_id
+                    } else {
+                        resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+                            crate::core::error::Error::Validation(
 							"rmcp server response id has no known correlation mapping and is not a string event id"
 								.to_string(),
 						)
-					})?
-				};
+                        })?
+                    };
 
-				self.transport
-					.send_response(&event_id, JsonRpcMessage::Response(resp))
-					.await
-			}
-			JsonRpcMessage::ErrorResponse(resp) => {
-				let request_key = serde_json::to_string(&resp.id).map_err(|e| {
-					crate::core::error::Error::Validation(format!(
-						"failed to serialize rmcp error response id for correlation lookup: {e}"
-					))
-				})?;
+                self.transport
+                    .send_response(&event_id, JsonRpcMessage::Response(resp))
+                    .await
+            }
+            JsonRpcMessage::ErrorResponse(resp) => {
+                let request_key = serde_json::to_string(&resp.id).map_err(|e| {
+                    crate::core::error::Error::Validation(format!(
+                        "failed to serialize rmcp error response id for correlation lookup: {e}"
+                    ))
+                })?;
 
-				let event_id = if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
-					event_id
-				} else {
-					resp.id.as_str().map(str::to_owned).ok_or_else(|| {
-						crate::core::error::Error::Validation(
+                let event_id =
+                    if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
+                        event_id
+                    } else {
+                        resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+                            crate::core::error::Error::Validation(
 							"rmcp server error response id has no known correlation mapping and is not a string event id"
 								.to_string(),
 						)
-					})?
-				};
+                        })?
+                    };
 
-				self.transport
-					.send_response(&event_id, JsonRpcMessage::ErrorResponse(resp))
-					.await
-			}
-			JsonRpcMessage::Notification(notification) => {
-				let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
-					crate::core::error::Error::Validation(
-						"cannot forward rmcp server notification: no active client bound"
-							.to_string(),
-					)
-				})?;
-				let message = JsonRpcMessage::Notification(notification);
-				self.transport.send_notification(target, &message, None).await
-			}
-			JsonRpcMessage::Request(request) => {
-				let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
-					crate::core::error::Error::Validation(
-						"cannot forward rmcp server request: no active client bound".to_string(),
-					)
-				})?;
-				let message = JsonRpcMessage::Request(request);
-				self.transport.send_notification(target, &message, None).await
-			}
-		}
-	}
+                self.transport
+                    .send_response(&event_id, JsonRpcMessage::ErrorResponse(resp))
+                    .await
+            }
+            JsonRpcMessage::Notification(notification) => {
+                let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
+                    crate::core::error::Error::Validation(
+                        "cannot forward rmcp server notification: no active client bound"
+                            .to_string(),
+                    )
+                })?;
+                let message = JsonRpcMessage::Notification(notification);
+                self.transport
+                    .send_notification(target, &message, None)
+                    .await
+            }
+            JsonRpcMessage::Request(request) => {
+                let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
+                    crate::core::error::Error::Validation(
+                        "cannot forward rmcp server request: no active client bound".to_string(),
+                    )
+                })?;
+                let message = JsonRpcMessage::Request(request);
+                self.transport
+                    .send_notification(target, &message, None)
+                    .await
+            }
+        }
+    }
 }

--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -127,13 +127,16 @@ impl BaseTransport {
         if should_encrypt {
             // Single-layer gift wrap: JSON.stringify(signedEvent) → NIP-44 encrypt
             // This matches the JS/TS SDK's encryptMessage(JSON.stringify(event), recipient)
-            let event_json = serde_json::to_string(&event)
+            let event_json =
+                serde_json::to_string(&event).map_err(|e| Error::Encryption(e.to_string()))?;
+            let signer = self
+                .relay_pool
+                .client()
+                .signer()
+                .await
                 .map_err(|e| Error::Encryption(e.to_string()))?;
-            let signer = self.relay_pool.client().signer().await
-                .map_err(|e| Error::Encryption(e.to_string()))?;
-            let gift_wrap_event = encryption::gift_wrap_single_layer(
-                &signer, recipient, &event_json,
-            ).await?;
+            let gift_wrap_event =
+                encryption::gift_wrap_single_layer(&signer, recipient, &event_json).await?;
             self.relay_pool.publish_event(&gift_wrap_event).await?;
             tracing::debug!(
                 signed_event_id = %signed_event_id,
@@ -192,24 +195,60 @@ mod tests {
 
     #[test]
     fn test_should_encrypt_disabled_mode() {
-        assert!(!should_encrypt(EncryptionMode::Disabled, CTXVM_MESSAGES_KIND, None));
-        assert!(!should_encrypt(EncryptionMode::Disabled, CTXVM_MESSAGES_KIND, Some(true)));
-        assert!(!should_encrypt(EncryptionMode::Disabled, CTXVM_MESSAGES_KIND, Some(false)));
+        assert!(!should_encrypt(
+            EncryptionMode::Disabled,
+            CTXVM_MESSAGES_KIND,
+            None
+        ));
+        assert!(!should_encrypt(
+            EncryptionMode::Disabled,
+            CTXVM_MESSAGES_KIND,
+            Some(true)
+        ));
+        assert!(!should_encrypt(
+            EncryptionMode::Disabled,
+            CTXVM_MESSAGES_KIND,
+            Some(false)
+        ));
     }
 
     #[test]
     fn test_should_encrypt_required_mode() {
-        assert!(should_encrypt(EncryptionMode::Required, CTXVM_MESSAGES_KIND, None));
-        assert!(should_encrypt(EncryptionMode::Required, CTXVM_MESSAGES_KIND, Some(false)));
-        assert!(should_encrypt(EncryptionMode::Required, CTXVM_MESSAGES_KIND, Some(true)));
+        assert!(should_encrypt(
+            EncryptionMode::Required,
+            CTXVM_MESSAGES_KIND,
+            None
+        ));
+        assert!(should_encrypt(
+            EncryptionMode::Required,
+            CTXVM_MESSAGES_KIND,
+            Some(false)
+        ));
+        assert!(should_encrypt(
+            EncryptionMode::Required,
+            CTXVM_MESSAGES_KIND,
+            Some(true)
+        ));
     }
 
     #[test]
     fn test_should_encrypt_optional_mode() {
         // Default (None) → true
-        assert!(should_encrypt(EncryptionMode::Optional, CTXVM_MESSAGES_KIND, None));
-        assert!(should_encrypt(EncryptionMode::Optional, CTXVM_MESSAGES_KIND, Some(true)));
-        assert!(!should_encrypt(EncryptionMode::Optional, CTXVM_MESSAGES_KIND, Some(false)));
+        assert!(should_encrypt(
+            EncryptionMode::Optional,
+            CTXVM_MESSAGES_KIND,
+            None
+        ));
+        assert!(should_encrypt(
+            EncryptionMode::Optional,
+            CTXVM_MESSAGES_KIND,
+            Some(true)
+        ));
+        assert!(!should_encrypt(
+            EncryptionMode::Optional,
+            CTXVM_MESSAGES_KIND,
+            Some(false)
+        ));
     }
 
     #[test]
@@ -237,10 +276,9 @@ mod tests {
         let keys = Keys::generate();
         let pubkey = keys.public_key();
         // Create a dummy event ID
-        let event_id = EventId::from_hex(
-            "0000000000000000000000000000000000000000000000000000000000000001",
-        )
-        .unwrap();
+        let event_id =
+            EventId::from_hex("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
         let tags = BaseTransport::create_response_tags(&pubkey, &event_id);
         assert_eq!(tags.len(), 2);
 

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -161,7 +161,7 @@ impl NostrClientTransport {
             jsonrpc: "2.0".to_string(),
             id: request_id.clone(),
             result: serde_json::json!({
-                "protocolVersion": crate::core::constants::MCP_PROTOCOL_VERSION,
+                "protocolVersion": crate::core::constants::mcp_protocol_version(),
                 "serverInfo": {
                     "name": "Emulated-Stateless-Server",
                     "version": "1.0.0"
@@ -284,7 +284,7 @@ mod tests {
             jsonrpc: "2.0".to_string(),
             id: request_id.clone(),
             result: serde_json::json!({
-                "protocolVersion": crate::core::constants::MCP_PROTOCOL_VERSION,
+                "protocolVersion": crate::core::constants::mcp_protocol_version(),
                 "serverInfo": {
                     "name": "Emulated-Stateless-Server",
                     "version": "1.0.0"

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -17,7 +17,7 @@ use crate::core::types::*;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
-use rmcp::model::ProtocolVersion;
+
 
 /// Configuration for the client transport.
 pub struct NostrClientTransportConfig {
@@ -134,10 +134,12 @@ impl NostrClientTransport {
             .send_mcp_message(message, &self.server_pubkey, CTXVM_MESSAGES_KIND, tags, None)
             .await?;
 
-        self.pending_requests
-            .write()
-            .await
-            .insert(event_id.to_hex());
+        if matches!(message, JsonRpcMessage::Request(_)) {
+            self.pending_requests
+                .write()
+                .await
+                .insert(event_id.to_hex());
+        }
 
         Ok(())
     }
@@ -154,7 +156,7 @@ impl NostrClientTransport {
             jsonrpc: "2.0".to_string(),
             id: request_id.clone(),
             result: serde_json::json!({
-                "protocolVersion": ProtocolVersion::LATEST.to_string(),
+                "protocolVersion": crate::core::constants::MCP_PROTOCOL_VERSION,
                 "serverInfo": {
                     "name": "Emulated-Stateless-Server",
                     "version": "1.0.0"
@@ -277,7 +279,7 @@ mod tests {
             jsonrpc: "2.0".to_string(),
             id: request_id.clone(),
             result: serde_json::json!({
-                "protocolVersion": ProtocolVersion::LATEST.to_string(),
+                "protocolVersion": crate::core::constants::MCP_PROTOCOL_VERSION,
                 "serverInfo": {
                     "name": "Emulated-Stateless-Server",
                     "version": "1.0.0"

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -18,7 +18,6 @@ use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
 
-
 /// Configuration for the client transport.
 pub struct NostrClientTransportConfig {
     /// Relay URLs to connect to.
@@ -131,7 +130,13 @@ impl NostrClientTransport {
         let tags = BaseTransport::create_recipient_tags(&self.server_pubkey);
         let event_id = self
             .base
-            .send_mcp_message(message, &self.server_pubkey, CTXVM_MESSAGES_KIND, tags, None)
+            .send_mcp_message(
+                message,
+                &self.server_pubkey,
+                CTXVM_MESSAGES_KIND,
+                tags,
+                None,
+            )
             .await?;
 
         if matches!(message, JsonRpcMessage::Request(_)) {
@@ -183,40 +188,40 @@ impl NostrClientTransport {
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
                 // Handle gift-wrapped events
-                let (actual_event_content, actual_pubkey, e_tag) =
-                    if event.kind == Kind::Custom(GIFT_WRAP_KIND)
-                        || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
-                    {
-                        // Single-layer NIP-44 decrypt (matches JS/TS SDK)
-                        let signer = match client.signer().await {
-                            Ok(s) => s,
-                            Err(e) => {
-                                tracing::error!("Failed to get signer: {e}");
-                                continue;
-                            }
-                        };
-                        match encryption::decrypt_gift_wrap_single_layer(&signer, &event).await {
-                            Ok(decrypted_json) => {
-                                match serde_json::from_str::<Event>(&decrypted_json) {
-                                    Ok(inner) => {
-                                        let e_tag = serializers::get_tag_value(&inner.tags, "e");
-                                        (inner.content, inner.pubkey, e_tag)
-                                    }
-                                    Err(e) => {
-                                        tracing::error!("Failed to parse inner event: {e}");
-                                        continue;
-                                    }
+                let (actual_event_content, actual_pubkey, e_tag) = if event.kind
+                    == Kind::Custom(GIFT_WRAP_KIND)
+                    || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
+                {
+                    // Single-layer NIP-44 decrypt (matches JS/TS SDK)
+                    let signer = match client.signer().await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::error!("Failed to get signer: {e}");
+                            continue;
+                        }
+                    };
+                    match encryption::decrypt_gift_wrap_single_layer(&signer, &event).await {
+                        Ok(decrypted_json) => {
+                            match serde_json::from_str::<Event>(&decrypted_json) {
+                                Ok(inner) => {
+                                    let e_tag = serializers::get_tag_value(&inner.tags, "e");
+                                    (inner.content, inner.pubkey, e_tag)
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to parse inner event: {e}");
+                                    continue;
                                 }
                             }
-                            Err(e) => {
-                                tracing::error!("Failed to decrypt gift wrap: {e}");
-                                continue;
-                            }
                         }
-                    } else {
-                        let e_tag = serializers::get_tag_value(&event.tags, "e");
-                        (event.content.clone(), event.pubkey, e_tag)
-                    };
+                        Err(e) => {
+                            tracing::error!("Failed to decrypt gift wrap: {e}");
+                            continue;
+                        }
+                    }
+                } else {
+                    let e_tag = serializers::get_tag_value(&event.tags, "e");
+                    (event.content.clone(), event.pubkey, e_tag)
+                };
 
                 // Verify it's from our server
                 if actual_pubkey != server_pubkey {
@@ -298,7 +303,10 @@ mod tests {
             assert!(r.result.get("capabilities").is_some());
             assert!(r.result.get("serverInfo").is_some());
             let server_info = r.result.get("serverInfo").unwrap();
-            assert_eq!(server_info.get("name").unwrap().as_str().unwrap(), "Emulated-Stateless-Server");
+            assert_eq!(
+                server_info.get("name").unwrap().as_str().unwrap(),
+                "Emulated-Stateless-Server"
+            );
         }
     }
 

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -395,6 +395,55 @@ impl NostrServerTransport {
         Ok(())
     }
 
+    /// Publish tools list from rmcp typed tool descriptors.
+    #[cfg(feature = "rmcp")]
+    pub async fn publish_tools_typed(&self, tools: Vec<rmcp::model::Tool>) -> Result<EventId> {
+        let tools = tools
+            .into_iter()
+            .map(serde_json::to_value)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        self.publish_tools(tools).await
+    }
+
+    /// Publish resources list from rmcp typed resource descriptors.
+    #[cfg(feature = "rmcp")]
+    pub async fn publish_resources_typed(
+        &self,
+        resources: Vec<rmcp::model::Resource>,
+    ) -> Result<EventId> {
+        let resources = resources
+            .into_iter()
+            .map(serde_json::to_value)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        self.publish_resources(resources).await
+    }
+
+    /// Publish prompts list from rmcp typed prompt descriptors.
+    #[cfg(feature = "rmcp")]
+    pub async fn publish_prompts_typed(
+        &self,
+        prompts: Vec<rmcp::model::Prompt>,
+    ) -> Result<EventId> {
+        let prompts = prompts
+            .into_iter()
+            .map(serde_json::to_value)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        self.publish_prompts(prompts).await
+    }
+
+    /// Publish resource templates list from rmcp typed template descriptors.
+    #[cfg(feature = "rmcp")]
+    pub async fn publish_resource_templates_typed(
+        &self,
+        templates: Vec<rmcp::model::ResourceTemplate>,
+    ) -> Result<EventId> {
+        let templates = templates
+            .into_iter()
+            .map(serde_json::to_value)
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        self.publish_resource_templates(templates).await
+    }
+
     // ── Internal ────────────────────────────────────────────────
 
     fn is_capability_excluded(

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -122,7 +122,16 @@ impl NostrServerTransport {
         let encryption_mode = self.config.encryption_mode;
 
         tokio::spawn(async move {
-            Self::event_loop(client, sessions, event_to_client, tx, allowed, excluded, encryption_mode).await;
+            Self::event_loop(
+                client,
+                sessions,
+                event_to_client,
+                tx,
+                allowed,
+                excluded,
+                encryption_mode,
+            )
+            .await;
         });
 
         // Spawn session cleanup
@@ -159,11 +168,7 @@ impl NostrServerTransport {
     }
 
     /// Send a response back to the client that sent the original request.
-    pub async fn send_response(
-        &self,
-        event_id: &str,
-        mut response: JsonRpcMessage,
-    ) -> Result<()> {
+    pub async fn send_response(&self, event_id: &str, mut response: JsonRpcMessage) -> Result<()> {
         let event_to_client = self.event_to_client.read().await;
         let client_pubkey_hex = event_to_client
             .get(event_id)
@@ -188,8 +193,8 @@ impl NostrServerTransport {
         let is_encrypted = session.is_encrypted;
         drop(sessions);
 
-        let client_pubkey = PublicKey::from_hex(&client_pubkey_hex)
-            .map_err(|e| Error::Other(e.to_string()))?;
+        let client_pubkey =
+            PublicKey::from_hex(&client_pubkey_hex).map_err(|e| Error::Other(e.to_string()))?;
 
         let event_id_parsed =
             EventId::from_hex(event_id).map_err(|e| Error::Other(e.to_string()))?;
@@ -236,8 +241,8 @@ impl NostrServerTransport {
         let is_encrypted = session.is_encrypted;
         drop(sessions);
 
-        let client_pubkey = PublicKey::from_hex(client_pubkey_hex)
-            .map_err(|e| Error::Other(e.to_string()))?;
+        let client_pubkey =
+            PublicKey::from_hex(client_pubkey_hex).map_err(|e| Error::Other(e.to_string()))?;
 
         let mut tags = BaseTransport::create_recipient_tags(&client_pubkey);
         if let Some(eid) = correlated_event_id {
@@ -329,8 +334,7 @@ impl NostrServerTransport {
             ));
         }
 
-        let builder =
-            EventBuilder::new(Kind::Custom(SERVER_ANNOUNCEMENT_KIND), content).tags(tags);
+        let builder = EventBuilder::new(Kind::Custom(SERVER_ANNOUNCEMENT_KIND), content).tags(tags);
 
         self.base.relay_pool.publish(builder).await
     }
@@ -385,11 +389,10 @@ impl NostrServerTransport {
         let _pubkey_hex = pubkey.to_hex();
 
         for kind in UNENCRYPTED_KINDS {
-            let builder = EventBuilder::new(Kind::Custom(5), reason)
-                .tag(Tag::custom(
-                    TagKind::Custom("k".into()),
-                    vec![kind.to_string()],
-                ));
+            let builder = EventBuilder::new(Kind::Custom(5), reason).tag(Tag::custom(
+                TagKind::Custom("k".into()),
+                vec![kind.to_string()],
+            ));
             self.base.relay_pool.publish(builder).await?;
         }
         Ok(())
@@ -481,60 +484,60 @@ impl NostrServerTransport {
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
-                let (content, sender_pubkey, event_id, is_encrypted) =
-                    if event.kind == Kind::Custom(GIFT_WRAP_KIND)
-                        || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
-                    {
-                        if encryption_mode == EncryptionMode::Disabled {
-                            tracing::warn!("Received encrypted message but encryption is disabled");
+                let (content, sender_pubkey, event_id, is_encrypted) = if event.kind
+                    == Kind::Custom(GIFT_WRAP_KIND)
+                    || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
+                {
+                    if encryption_mode == EncryptionMode::Disabled {
+                        tracing::warn!("Received encrypted message but encryption is disabled");
+                        continue;
+                    }
+                    // Single-layer NIP-44 decrypt (matches JS/TS SDK)
+                    let signer = match client.signer().await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::error!("Failed to get signer: {e}");
                             continue;
                         }
-                        // Single-layer NIP-44 decrypt (matches JS/TS SDK)
-                        let signer = match client.signer().await {
-                            Ok(s) => s,
-                            Err(e) => {
-                                tracing::error!("Failed to get signer: {e}");
-                                continue;
-                            }
-                        };
-                        match encryption::decrypt_gift_wrap_single_layer(&signer, &event).await {
-                            Ok(decrypted_json) => {
-                                // The decrypted content is JSON of the inner signed event.
-                                // Use the INNER event's ID for correlation — the client
-                                // registers the inner event ID in its correlation store.
-                                match serde_json::from_str::<Event>(&decrypted_json) {
-                                    Ok(inner) => (
-                                        inner.content,
-                                        inner.pubkey.to_hex(),
-                                        inner.id.to_hex(),
-                                        true,
-                                    ),
-                                    Err(e) => {
-                                        tracing::error!("Failed to parse inner event: {e}");
-                                        continue;
-                                    }
+                    };
+                    match encryption::decrypt_gift_wrap_single_layer(&signer, &event).await {
+                        Ok(decrypted_json) => {
+                            // The decrypted content is JSON of the inner signed event.
+                            // Use the INNER event's ID for correlation — the client
+                            // registers the inner event ID in its correlation store.
+                            match serde_json::from_str::<Event>(&decrypted_json) {
+                                Ok(inner) => (
+                                    inner.content,
+                                    inner.pubkey.to_hex(),
+                                    inner.id.to_hex(),
+                                    true,
+                                ),
+                                Err(e) => {
+                                    tracing::error!("Failed to parse inner event: {e}");
+                                    continue;
                                 }
                             }
-                            Err(e) => {
-                                tracing::error!("Failed to decrypt: {e}");
-                                continue;
-                            }
                         }
-                    } else {
-                        if encryption_mode == EncryptionMode::Required {
-                            tracing::warn!(
-                                pubkey = %event.pubkey,
-                                "Received unencrypted message but encryption is required"
-                            );
+                        Err(e) => {
+                            tracing::error!("Failed to decrypt: {e}");
                             continue;
                         }
-                        (
-                            event.content.clone(),
-                            event.pubkey.to_hex(),
-                            event.id.to_hex(),
-                            false,
-                        )
-                    };
+                    }
+                } else {
+                    if encryption_mode == EncryptionMode::Required {
+                        tracing::warn!(
+                            pubkey = %event.pubkey,
+                            "Received unencrypted message but encryption is required"
+                        );
+                        continue;
+                    }
+                    (
+                        event.content.clone(),
+                        event.pubkey.to_hex(),
+                        event.id.to_hex(),
+                        false,
+                    )
+                };
 
                 // Parse MCP message
                 let mcp_msg = match serializers::nostr_event_to_mcp_message(&content) {
@@ -688,22 +691,36 @@ mod tests {
 
         // Insert a session with an old activity time
         let mut session = ClientSession::new(false);
-        session.pending_requests.insert("evt1".to_string(), serde_json::json!(1));
-        sessions.write().await.insert("pubkey1".to_string(), session);
-        event_to_client.write().await.insert("evt1".to_string(), "pubkey1".to_string());
+        session
+            .pending_requests
+            .insert("evt1".to_string(), serde_json::json!(1));
+        sessions
+            .write()
+            .await
+            .insert("pubkey1".to_string(), session);
+        event_to_client
+            .write()
+            .await
+            .insert("evt1".to_string(), "pubkey1".to_string());
 
         // With a long timeout, nothing should be cleaned
         let cleaned = NostrServerTransport::cleanup_sessions(
-            &sessions, &event_to_client, Duration::from_secs(300),
-        ).await;
+            &sessions,
+            &event_to_client,
+            Duration::from_secs(300),
+        )
+        .await;
         assert_eq!(cleaned, 0);
         assert_eq!(sessions.read().await.len(), 1);
 
         // With zero timeout, it should be cleaned
         thread::sleep(Duration::from_millis(5));
         let cleaned = NostrServerTransport::cleanup_sessions(
-            &sessions, &event_to_client, Duration::from_millis(1),
-        ).await;
+            &sessions,
+            &event_to_client,
+            Duration::from_millis(1),
+        )
+        .await;
         assert_eq!(cleaned, 1);
         assert!(sessions.read().await.is_empty());
         assert!(event_to_client.read().await.is_empty());
@@ -718,8 +735,11 @@ mod tests {
         sessions.write().await.insert("active".to_string(), session);
 
         let cleaned = NostrServerTransport::cleanup_sessions(
-            &sessions, &event_to_client, Duration::from_secs(300),
-        ).await;
+            &sessions,
+            &event_to_client,
+            Duration::from_secs(300),
+        )
+        .await;
         assert_eq!(cleaned, 0);
         assert_eq!(sessions.read().await.len(), 1);
     }
@@ -729,24 +749,44 @@ mod tests {
     #[test]
     fn test_pending_request_tracking() {
         let mut session = ClientSession::new(false);
-        session.pending_requests.insert("event_abc".to_string(), serde_json::json!(42));
-        assert_eq!(session.pending_requests.get("event_abc"), Some(&serde_json::json!(42)));
+        session
+            .pending_requests
+            .insert("event_abc".to_string(), serde_json::json!(42));
+        assert_eq!(
+            session.pending_requests.get("event_abc"),
+            Some(&serde_json::json!(42))
+        );
     }
 
     #[test]
     fn test_progress_token_tracking() {
         let mut session = ClientSession::new(false);
-        session.event_to_progress_token.insert("evt1".to_string(), "token1".to_string());
-        session.pending_requests.insert("token1".to_string(), serde_json::json!("evt1"));
-        assert_eq!(session.event_to_progress_token.get("evt1"), Some(&"token1".to_string()));
+        session
+            .event_to_progress_token
+            .insert("evt1".to_string(), "token1".to_string());
+        session
+            .pending_requests
+            .insert("token1".to_string(), serde_json::json!("evt1"));
+        assert_eq!(
+            session.event_to_progress_token.get("evt1"),
+            Some(&"token1".to_string())
+        );
     }
 
     // ── Authorization (is_capability_excluded) ──────────────────
 
     #[test]
     fn test_initialize_always_excluded() {
-        assert!(NostrServerTransport::is_capability_excluded(&[], "initialize", None));
-        assert!(NostrServerTransport::is_capability_excluded(&[], "notifications/initialized", None));
+        assert!(NostrServerTransport::is_capability_excluded(
+            &[],
+            "initialize",
+            None
+        ));
+        assert!(NostrServerTransport::is_capability_excluded(
+            &[],
+            "notifications/initialized",
+            None
+        ));
     }
 
     #[test]
@@ -755,8 +795,16 @@ mod tests {
             method: "tools/list".to_string(),
             name: None,
         }];
-        assert!(NostrServerTransport::is_capability_excluded(&exclusions, "tools/list", None));
-        assert!(NostrServerTransport::is_capability_excluded(&exclusions, "tools/list", Some("anything")));
+        assert!(NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "tools/list",
+            None
+        ));
+        assert!(NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "tools/list",
+            Some("anything")
+        ));
     }
 
     #[test]
@@ -765,9 +813,21 @@ mod tests {
             method: "tools/call".to_string(),
             name: Some("get_weather".to_string()),
         }];
-        assert!(NostrServerTransport::is_capability_excluded(&exclusions, "tools/call", Some("get_weather")));
-        assert!(!NostrServerTransport::is_capability_excluded(&exclusions, "tools/call", Some("other_tool")));
-        assert!(!NostrServerTransport::is_capability_excluded(&exclusions, "tools/call", None));
+        assert!(NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "tools/call",
+            Some("get_weather")
+        ));
+        assert!(!NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "tools/call",
+            Some("other_tool")
+        ));
+        assert!(!NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "tools/call",
+            None
+        ));
     }
 
     #[test]
@@ -776,14 +836,30 @@ mod tests {
             method: "tools/list".to_string(),
             name: None,
         }];
-        assert!(!NostrServerTransport::is_capability_excluded(&exclusions, "tools/call", None));
-        assert!(!NostrServerTransport::is_capability_excluded(&exclusions, "resources/list", None));
+        assert!(!NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "tools/call",
+            None
+        ));
+        assert!(!NostrServerTransport::is_capability_excluded(
+            &exclusions,
+            "resources/list",
+            None
+        ));
     }
 
     #[test]
     fn test_empty_exclusions_non_init_method() {
-        assert!(!NostrServerTransport::is_capability_excluded(&[], "tools/list", None));
-        assert!(!NostrServerTransport::is_capability_excluded(&[], "tools/call", Some("x")));
+        assert!(!NostrServerTransport::is_capability_excluded(
+            &[],
+            "tools/list",
+            None
+        ));
+        assert!(!NostrServerTransport::is_capability_excluded(
+            &[],
+            "tools/call",
+            Some("x")
+        ));
     }
 
     // ── Encryption mode enforcement ─────────────────────────────


### PR DESCRIPTION
# PR: RMCP Integration with Backward-Compatible Nostr Transport

## Main Goal
Introduce RMCP support in the Rust SDK while keeping the existing JSON-RPC-over-Nostr transport and APIs stable for current users.

## Why This Change
- Enable RMCP-native development patterns (typed handlers, tools/resources flow) in the Rust SDK.
- Reuse the existing Nostr transport stack instead of introducing a parallel transport system.
- Allow teams to adopt RMCP incrementally without breaking existing integrations.

## What We Implemented
- Added RMCP dependency wiring and feature-gated integration.
- Introduced an RMCP bridge layer for message conversion between internal JSON-RPC and RMCP message types.
- Implemented RMCP worker adapters for both server and client sides over Nostr transport.
- Added additive high-level startup helpers for RMCP usage in gateway/proxy flows.
- Expanded tests for conversion and pipeline/correlation behavior.
- Upgraded integration example coverage with scenario matrix:
  - Local RMCP (in-process)
  - Hybrid relay mode (RMCP server + legacy client)
  - Full RMCP over relays (RMCP server + RMCP client)

## Key Backward-Compatibility Decisions
- **Additive API design:** RMCP APIs were added without removing or changing legacy APIs.
- **Feature-based rollout:** RMCP integration is controlled via feature flags.
- **Hybrid interoperability:** Supports RMCP server with legacy JSON-RPC clients.
- **Legacy wire-path preservation:** Existing JSON-RPC transport behavior remains unchanged.
- **Safe routing semantics:** Worker binding and correlation safeguards prevent cross-session response leakage.
