### PR TITLE
fix: add missing util::logger module for rmcp build

### DIFF
--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 
 use crate::core::error::Result;
 use crate::core::types::JsonRpcMessage;
-use crate::util::logger;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use crate::transport::server::{NostrServerTransport, NostrServerTransportConfig};
 use rmcp::transport::worker::{Worker, WorkerContext, WorkerQuitReason};

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -1,0 +1,14 @@
+//! Thin wrappers around `tracing` for stable call sites (e.g. rmcp conversion).
+//!
+//! Note: `tracing` macros require a string-literal `target:` for callsite registration.
+//! The `logical_target` field preserves the module-style string passed by callers.
+
+/// Log at error level; `logical_target` is the caller’s notion of module/path (for filters in output).
+pub fn error_with_target(logical_target: &str, message: impl std::fmt::Display) {
+    tracing::error!(
+        target: "contextvm_sdk",
+        logical_target = logical_target,
+        "{}",
+        message
+    );
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! Small shared helpers (logging wrappers, etc.).
+
+pub mod logger;


### PR DESCRIPTION
`cargo build` was failing for everyone after #3 ,`pub mod util` was declared in lib.rs and `util::logger` was imported in rmcp_transport/convert.rs and worker.rs, but the module was never committed.

Adds src/util/mod.rs and src/util/logger.rs with the error_with_target wrapper. Also removes the now-unused logger import from worker.rs since it uses tracing macros directly.

87 tests passing after this fix.

Before:

<img width="784" height="216" alt="Screenshot 2026-04-05 at 11 46 13 PM" src="https://github.com/user-attachments/assets/033a152d-ebe0-4ad0-9984-2c63092b2145" />

After:
<img width="752" height="170" alt="Screenshot 2026-04-05 at 11 47 03 PM" src="https://github.com/user-attachments/assets/0468f415-3730-4cc2-aa55-454739de0d9c" />
