### PR TITLE
Implementation of Logger unit 

### DIFF
--- a/examples/gateway.rs
+++ b/examples/gateway.rs
@@ -2,6 +2,8 @@
 //!
 //! This demonstrates how to create a ContextVM gateway that receives
 //! MCP requests over Nostr and responds to them.
+//!
+//! Usage: cargo run --example gateway -- [--log-file <path>]
 
 use contextvm_sdk::core::types::*;
 use contextvm_sdk::gateway::{GatewayConfig, NostrMCPGateway};
@@ -10,7 +12,25 @@ use contextvm_sdk::transport::server::NostrServerTransportConfig;
 
 #[tokio::main]
 async fn main() -> contextvm_sdk::Result<()> {
-    tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut log_file_path: Option<String> = None;
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--log-file" => {
+                index += 1;
+                let Some(path) = args.get(index) else {
+                    panic!("Usage: gateway [--log-file <path>]");
+                };
+                log_file_path = Some(path.clone());
+            }
+            other => {
+                panic!("Unknown argument: {other}. Usage: gateway [--log-file <path>]");
+            }
+        }
+        index += 1;
+    }
 
     // Generate ephemeral keys for this session
     let keys = signer::generate();
@@ -26,6 +46,7 @@ async fn main() -> contextvm_sdk::Result<()> {
                 ..Default::default()
             }),
             is_announced_server: true,
+            log_file_path,
             ..Default::default()
         },
     };

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,6 +1,6 @@
 //! Example: Connect to a remote MCP server via Nostr and call tools/list.
 //!
-//! Usage: cargo run --example proxy -- <server_pubkey_hex>
+//! Usage: cargo run --example proxy -- <server_pubkey_hex> [--log-file <path>]
 
 use contextvm_sdk::core::types::*;
 use contextvm_sdk::proxy::{NostrMCPProxy, ProxyConfig};
@@ -8,11 +8,35 @@ use contextvm_sdk::signer;
 use contextvm_sdk::transport::client::NostrClientTransportConfig;
 #[tokio::main]
 async fn main() -> contextvm_sdk::Result<()> {
-    tracing_subscriber::fmt::init();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut server_pubkey_hex: Option<String> = None;
+    let mut log_file_path: Option<String> = None;
 
-    let server_pubkey_hex = std::env::args()
-        .nth(1)
-        .expect("Usage: proxy <server_pubkey_hex>");
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--log-file" => {
+                index += 1;
+                let Some(path) = args.get(index) else {
+                    panic!("Usage: proxy <server_pubkey_hex> [--log-file <path>]");
+                };
+                log_file_path = Some(path.clone());
+            }
+            value => {
+                if server_pubkey_hex.is_none() {
+                    server_pubkey_hex = Some(value.to_string());
+                } else {
+                    panic!(
+                        "Unknown argument: {value}. Usage: proxy <server_pubkey_hex> [--log-file <path>]"
+                    );
+                }
+            }
+        }
+        index += 1;
+    }
+
+    let server_pubkey_hex =
+        server_pubkey_hex.expect("Usage: proxy <server_pubkey_hex> [--log-file <path>]");
 
     let keys = signer::generate();
     println!("Client pubkey: {}", keys.public_key().to_hex());
@@ -22,6 +46,7 @@ async fn main() -> contextvm_sdk::Result<()> {
             relay_urls: vec!["wss://relay.damus.io".to_string()],
             server_pubkey: server_pubkey_hex,
             encryption_mode: EncryptionMode::Optional,
+            log_file_path,
             ..Default::default()
         },
     };

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -109,7 +109,6 @@ pub const UNENCRYPTED_KINDS: &[u16] = &[
     PROMPTS_LIST_KIND,
 ];
 
-
 #[cfg(feature = "rmcp")]
 pub fn mcp_protocol_version() -> &'static str {
     use std::sync::OnceLock;

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -141,10 +141,7 @@ mod tests {
     ///   2. NIP-44 encrypt the plaintext using ephemeral_secret + recipient_pubkey
     ///   3. Build kind 1059 event with encrypted content, `p` tag = recipient
     ///   4. Sign with ephemeral key
-    async fn create_simple_gift_wrap(
-        plaintext: &str,
-        recipient: &PublicKey,
-    ) -> (Event, Keys) {
+    async fn create_simple_gift_wrap(plaintext: &str, recipient: &PublicKey) -> (Event, Keys) {
         let ephemeral = Keys::generate();
 
         // Single-layer NIP-44 encrypt

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -127,6 +127,7 @@ mod tests {
             excluded_capabilities: vec![],
             cleanup_interval: Duration::from_secs(120),
             session_timeout: Duration::from_secs(600),
+            log_file_path: None,
         };
 
         let config = GatewayConfig { nostr_config };

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -112,6 +112,7 @@ mod tests {
             encryption_mode: EncryptionMode::Required,
             is_stateless: true,
             timeout: Duration::from_secs(60),
+            log_file_path: None,
         };
 
         let config = ProxyConfig { nostr_config };

--- a/src/rmcp_transport/convert.rs
+++ b/src/rmcp_transport/convert.rs
@@ -6,6 +6,12 @@
 use crate::core::types::JsonRpcMessage;
 use crate::util::logger;
 
+const LOG_TARGET: &str = "contextvm_sdk::rmcp_transport::convert";
+
+fn log_conversion_error(direction: &str, details: impl AsRef<str>) {
+    logger::error_with_target(LOG_TARGET, format!("{direction}: {}", details.as_ref()));
+}
+
 /// Convert internal JSON-RPC message into rmcp server RX message.
 ///
 /// Role mapping:
@@ -14,15 +20,12 @@ pub fn internal_to_rmcp_server_rx(
     msg: &JsonRpcMessage,
 ) -> Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleServer>> {
     let direction = "internal_to_rmcp_server_rx";
-    let target = "contextvm_sdk::rmcp_transport::convert";
     let value = match serde_json::to_value(msg) {
         Ok(value) => value,
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to serialize message into intermediate JSON: {error}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to serialize message into intermediate JSON: {error}"),
             );
             return None;
         }
@@ -31,11 +34,9 @@ pub fn internal_to_rmcp_server_rx(
     match serde_json::from_value(value.clone()) {
         Ok(parsed) => Some(parsed),
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to parse converted JSON payload: {error}; payload={value:?}"),
             );
             None
         }
@@ -50,15 +51,12 @@ pub fn internal_to_rmcp_client_rx(
     msg: &JsonRpcMessage,
 ) -> Option<rmcp::service::RxJsonRpcMessage<rmcp::RoleClient>> {
     let direction = "internal_to_rmcp_client_rx";
-    let target = "contextvm_sdk::rmcp_transport::convert";
     let value = match serde_json::to_value(msg) {
         Ok(value) => value,
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to serialize message into intermediate JSON: {error}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to serialize message into intermediate JSON: {error}"),
             );
             return None;
         }
@@ -67,11 +65,9 @@ pub fn internal_to_rmcp_client_rx(
     match serde_json::from_value(value.clone()) {
         Ok(parsed) => Some(parsed),
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to parse converted JSON payload: {error}; payload={value:?}"),
             );
             None
         }
@@ -83,15 +79,12 @@ pub fn rmcp_server_tx_to_internal(
     msg: rmcp::service::TxJsonRpcMessage<rmcp::RoleServer>,
 ) -> Option<JsonRpcMessage> {
     let direction = "rmcp_server_tx_to_internal";
-    let target = "contextvm_sdk::rmcp_transport::convert";
     let value = match serde_json::to_value(msg) {
         Ok(value) => value,
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to serialize message into intermediate JSON: {error}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to serialize message into intermediate JSON: {error}"),
             );
             return None;
         }
@@ -100,11 +93,9 @@ pub fn rmcp_server_tx_to_internal(
     match serde_json::from_value(value.clone()) {
         Ok(parsed) => Some(parsed),
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to parse converted JSON payload: {error}; payload={value:?}"),
             );
             None
         }
@@ -116,15 +107,12 @@ pub fn rmcp_client_tx_to_internal(
     msg: rmcp::service::TxJsonRpcMessage<rmcp::RoleClient>,
 ) -> Option<JsonRpcMessage> {
     let direction = "rmcp_client_tx_to_internal";
-    let target = "contextvm_sdk::rmcp_transport::convert";
     let value = match serde_json::to_value(msg) {
         Ok(value) => value,
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to serialize message into intermediate JSON: {error}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to serialize message into intermediate JSON: {error}"),
             );
             return None;
         }
@@ -133,11 +121,9 @@ pub fn rmcp_client_tx_to_internal(
     match serde_json::from_value(value.clone()) {
         Ok(parsed) => Some(parsed),
         Err(error) => {
-            logger::error_with_target(
-                target,
-                format!(
-                    "{direction}: failed to parse converted JSON payload: {error}; payload={value:?}"
-                ),
+            log_conversion_error(
+                direction,
+                format!("failed to parse converted JSON payload: {error}; payload={value:?}"),
             );
             None
         }

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -7,15 +7,17 @@ use std::collections::HashMap;
 
 use crate::core::error::Result;
 use crate::core::types::JsonRpcMessage;
-use crate::util::logger;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use crate::transport::server::{NostrServerTransport, NostrServerTransportConfig};
+use crate::util::logger;
 use rmcp::transport::worker::{Worker, WorkerContext, WorkerQuitReason};
 
 use super::convert::{
     internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
     rmcp_server_tx_to_internal,
 };
+
+const LOG_TARGET: &str = "contextvm_sdk::rmcp_transport::worker";
 
 /// rmcp server worker wrapper for ContextVM Nostr server transport.
 pub struct NostrServerWorker {
@@ -32,7 +34,17 @@ impl NostrServerWorker {
     where
         T: nostr_sdk::prelude::IntoNostrSigner,
     {
-        let transport = NostrServerTransport::new(signer, config).await?;
+        let transport = NostrServerTransport::new(signer, config)
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!("Failed to initialize server worker transport: {error}"),
+                );
+                error
+            })?;
+
+        logger::info_with_target(LOG_TARGET, "Initialized rmcp server worker transport");
         Ok(Self {
             transport,
             active_client_pubkey: None,
@@ -51,10 +63,12 @@ impl Worker for NostrServerWorker {
     type Role = rmcp::RoleServer;
 
     fn err_closed() -> Self::Error {
+        logger::warn_with_target(LOG_TARGET, "rmcp server worker channel closed");
         Self::Error::Transport("rmcp worker channel closed".to_string())
     }
 
     fn err_join(e: tokio::task::JoinError) -> Self::Error {
+        logger::error_with_target(LOG_TARGET, format!("rmcp server worker join error: {e}"));
         Self::Error::Other(format!("rmcp worker join error: {e}"))
     }
 
@@ -95,15 +109,21 @@ impl Worker for NostrServerWorker {
 
                     match &self.active_client_pubkey {
                         Some(active) if active != &client_pubkey => {
-                            tracing::warn!(
-                                active_client = %active,
-                                ignored_client = %client_pubkey,
-                                "Ignoring message from second client: rmcp server worker currently supports one active client per worker"
+                            logger::warn_with_target(
+                                LOG_TARGET,
+                                format!(
+                                    "Ignoring message from second client: rmcp server worker currently supports one active client per worker; active_client={active}; ignored_client={client_pubkey}"
+                                ),
                             );
                             continue;
                         }
                         None => {
-                            tracing::info!(client_pubkey = %client_pubkey, "Binding rmcp server worker to first client session");
+                            logger::info_with_target(
+                                LOG_TARGET,
+                                format!(
+                                    "Binding rmcp server worker to first client session; client_pubkey={client_pubkey}"
+                                ),
+                            );
                             self.active_client_pubkey = Some(client_pubkey.clone());
                         }
                         _ => {}
@@ -115,7 +135,10 @@ impl Worker for NostrServerWorker {
                                 self.request_id_to_event_id.insert(request_key, event_id);
                             }
                             Err(e) => {
-                                tracing::warn!("Failed to serialize request id for correlation map: {e}");
+                                logger::warn_with_target(
+                                    LOG_TARGET,
+                                    format!("Failed to serialize request id for correlation map: {e}"),
+                                );
                             }
                         }
                     }
@@ -125,7 +148,10 @@ impl Worker for NostrServerWorker {
                             break reason;
                         }
                     } else {
-                        tracing::warn!("Failed to convert incoming server-side message to rmcp format");
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            "Failed to convert incoming server-side message to rmcp format",
+                        );
                     }
                 }
                 outbound = context.recv_from_handler() => {
@@ -148,7 +174,10 @@ impl Worker for NostrServerWorker {
         };
 
         if let Err(e) = self.transport.close().await {
-            tracing::warn!("Failed to close server transport cleanly: {e}");
+            logger::warn_with_target(
+                LOG_TARGET,
+                format!("Failed to close server transport cleanly: {e}"),
+            );
         }
 
         Err(quit_reason)
@@ -166,7 +195,16 @@ impl NostrClientWorker {
     where
         T: nostr_sdk::prelude::IntoNostrSigner,
     {
-        let transport = NostrClientTransport::new(signer, config).await?;
+        let transport = NostrClientTransport::new(signer, config)
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!("Failed to initialize client worker transport: {error}"),
+                );
+                error
+            })?;
+        logger::info_with_target(LOG_TARGET, "Initialized rmcp client worker transport");
         Ok(Self { transport })
     }
 
@@ -181,10 +219,12 @@ impl Worker for NostrClientWorker {
     type Role = rmcp::RoleClient;
 
     fn err_closed() -> Self::Error {
+        logger::warn_with_target(LOG_TARGET, "rmcp client worker channel closed");
         Self::Error::Transport("rmcp worker channel closed".to_string())
     }
 
     fn err_join(e: tokio::task::JoinError) -> Self::Error {
+        logger::error_with_target(LOG_TARGET, format!("rmcp client worker join error: {e}"));
         Self::Error::Other(format!("rmcp worker join error: {e}"))
     }
 
@@ -221,7 +261,10 @@ impl Worker for NostrClientWorker {
                             break reason;
                         }
                     } else {
-                        tracing::warn!("Failed to convert incoming client-side message to rmcp format");
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            "Failed to convert incoming client-side message to rmcp format",
+                        );
                     }
                 }
                 outbound = context.recv_from_handler() => {
@@ -244,7 +287,10 @@ impl Worker for NostrClientWorker {
         };
 
         if let Err(e) = self.transport.close().await {
-            tracing::warn!("Failed to close client transport cleanly: {e}");
+            logger::warn_with_target(
+                LOG_TARGET,
+                format!("Failed to close client transport cleanly: {e}"),
+            );
         }
 
         Err(quit_reason)

--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -10,6 +10,9 @@ use crate::core::types::{EncryptionMode, JsonRpcMessage};
 use crate::core::validation;
 use crate::encryption;
 use crate::relay::RelayPool;
+use crate::util::logger;
+
+const LOG_TARGET: &str = "contextvm_sdk::transport::base";
 
 /// Shared transport logic for both client and server.
 ///
@@ -88,7 +91,10 @@ impl BaseTransport {
     /// Convert a Nostr event to an MCP message with validation.
     pub fn convert_event_to_mcp(&self, content: &str) -> Option<JsonRpcMessage> {
         if !validation::validate_message_size(content) {
-            tracing::warn!("Message size validation failed: {} bytes", content.len());
+            logger::warn_with_target(
+                LOG_TARGET,
+                format!("Message size validation failed: {} bytes", content.len()),
+            );
             return None;
         }
 
@@ -138,14 +144,19 @@ impl BaseTransport {
             let gift_wrap_event =
                 encryption::gift_wrap_single_layer(&signer, recipient, &event_json).await?;
             self.relay_pool.publish_event(&gift_wrap_event).await?;
-            tracing::debug!(
-                signed_event_id = %signed_event_id,
-                envelope_id = %gift_wrap_event.id,
-                "Sent encrypted MCP message"
+            logger::debug_with_target(
+                LOG_TARGET,
+                format!(
+                    "Sent encrypted MCP message; signed_event_id={signed_event_id}; envelope_id={}",
+                    gift_wrap_event.id
+                ),
             );
         } else {
             self.relay_pool.publish_event(&event).await?;
-            tracing::debug!(signed_event_id = %signed_event_id, "Sent unencrypted MCP message");
+            logger::debug_with_target(
+                LOG_TARGET,
+                format!("Sent unencrypted MCP message; signed_event_id={signed_event_id}"),
+            );
         }
 
         Ok(signed_event_id)

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -17,6 +17,9 @@ use crate::core::types::*;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
+use crate::util::logger;
+
+const LOG_TARGET: &str = "contextvm_sdk::transport::client";
 
 /// Configuration for the client transport.
 pub struct NostrClientTransportConfig {
@@ -30,6 +33,8 @@ pub struct NostrClientTransportConfig {
     pub is_stateless: bool,
     /// Response timeout (default: 30s).
     pub timeout: Duration,
+    /// Optional log file path used by all SDK modules.
+    pub log_file_path: Option<String>,
 }
 
 impl Default for NostrClientTransportConfig {
@@ -40,6 +45,7 @@ impl Default for NostrClientTransportConfig {
             encryption_mode: EncryptionMode::Optional,
             is_stateless: false,
             timeout: Duration::from_secs(30),
+            log_file_path: None,
         }
     }
 }
@@ -62,12 +68,31 @@ impl NostrClientTransport {
     where
         T: IntoNostrSigner,
     {
-        let server_pubkey = PublicKey::from_hex(&config.server_pubkey)
-            .map_err(|e| Error::Other(format!("Invalid server pubkey: {e}")))?;
+        logger::set_global_log_file_path(config.log_file_path.clone());
 
-        let relay_pool = Arc::new(RelayPool::new(signer).await?);
+        let server_pubkey = PublicKey::from_hex(&config.server_pubkey).map_err(|e| {
+            logger::error_with_target(LOG_TARGET, format!("Invalid server pubkey: {e}"));
+            Error::Other(format!("Invalid server pubkey: {e}"))
+        })?;
+
+        let relay_pool = Arc::new(RelayPool::new(signer).await.map_err(|error| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!("Failed to initialize relay pool for client transport: {error}"),
+            );
+            error
+        })?);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
+        logger::info_with_target(
+            LOG_TARGET,
+            format!(
+                "Created client transport; relay_count={}; stateless={}; encryption_mode={:?}",
+                config.relay_urls.len(),
+                config.is_stateless,
+                config.encryption_mode,
+            ),
+        );
         Ok(Self {
             base: BaseTransport {
                 relay_pool,
@@ -84,12 +109,42 @@ impl NostrClientTransport {
 
     /// Connect and start listening for responses.
     pub async fn start(&mut self) -> Result<()> {
-        self.base.connect(&self.config.relay_urls).await?;
+        self.base
+            .connect(&self.config.relay_urls)
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!("Failed to connect client transport to relays: {error}"),
+                );
+                error
+            })?;
 
-        let pubkey = self.base.get_public_key().await?;
-        tracing::info!(pubkey = %pubkey.to_hex(), "Client transport started");
+        let pubkey = self.base.get_public_key().await.map_err(|error| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!("Failed to fetch client transport public key: {error}"),
+            );
+            error
+        })?;
+        logger::info_with_target(
+            LOG_TARGET,
+            format!("Client transport started; pubkey={}", pubkey.to_hex()),
+        );
 
-        self.base.subscribe_for_pubkey(&pubkey).await?;
+        self.base
+            .subscribe_for_pubkey(&pubkey)
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!(
+                        "Failed to subscribe client transport for pubkey {}: {error}",
+                        pubkey.to_hex(),
+                    ),
+                );
+                error
+            })?;
 
         // Spawn event loop
         let client = self.base.relay_pool.client().clone();
@@ -102,6 +157,13 @@ impl NostrClientTransport {
             Self::event_loop(client, pending, server_pubkey, tx, encryption_mode).await;
         });
 
+        logger::info_with_target(
+            LOG_TARGET,
+            format!(
+                "Client transport event loop spawned; relay_count={}",
+                self.config.relay_urls.len(),
+            ),
+        );
         Ok(())
     }
 
@@ -137,7 +199,18 @@ impl NostrClientTransport {
                 tags,
                 None,
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!(
+                        "Failed to send client message; server_pubkey={}; method={:?}; error={error}",
+                        self.server_pubkey.to_hex(),
+                        message.method(),
+                    ),
+                );
+                error
+            })?;
 
         if matches!(message, JsonRpcMessage::Request(_)) {
             self.pending_requests
@@ -146,6 +219,14 @@ impl NostrClientTransport {
                 .insert(event_id.to_hex());
         }
 
+        logger::debug_with_target(
+            LOG_TARGET,
+            format!(
+                "Sent client message; event_id={}; method={:?}",
+                event_id.to_hex(),
+                message.method(),
+            ),
+        );
         Ok(())
     }
 
@@ -196,7 +277,10 @@ impl NostrClientTransport {
                     let signer = match client.signer().await {
                         Ok(s) => s,
                         Err(e) => {
-                            tracing::error!("Failed to get signer: {e}");
+                            logger::error_with_target(
+                                LOG_TARGET,
+                                format!("Failed to get signer: {e}"),
+                            );
                             continue;
                         }
                     };
@@ -208,13 +292,19 @@ impl NostrClientTransport {
                                     (inner.content, inner.pubkey, e_tag)
                                 }
                                 Err(e) => {
-                                    tracing::error!("Failed to parse inner event: {e}");
+                                    logger::error_with_target(
+                                        LOG_TARGET,
+                                        format!("Failed to parse inner event: {e}"),
+                                    );
                                     continue;
                                 }
                             }
                         }
                         Err(e) => {
-                            tracing::error!("Failed to decrypt gift wrap: {e}");
+                            logger::error_with_target(
+                                LOG_TARGET,
+                                format!("Failed to decrypt gift wrap: {e}"),
+                            );
                             continue;
                         }
                     }
@@ -225,7 +315,7 @@ impl NostrClientTransport {
 
                 // Verify it's from our server
                 if actual_pubkey != server_pubkey {
-                    tracing::debug!("Skipping event from unexpected pubkey");
+                    logger::debug_with_target(LOG_TARGET, "Skipping event from unexpected pubkey");
                     continue;
                 }
 
@@ -233,7 +323,10 @@ impl NostrClientTransport {
                 if let Some(ref correlated_id) = e_tag {
                     let is_pending = pending.read().await.contains(correlated_id.as_str());
                     if !is_pending {
-                        tracing::warn!(e_tag = %correlated_id, "Response for unknown request");
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            format!("Response for unknown request; e_tag={correlated_id}"),
+                        );
                         continue;
                     }
                 }
@@ -265,6 +358,7 @@ mod tests {
         assert_eq!(config.encryption_mode, EncryptionMode::Optional);
         assert!(!config.is_stateless);
         assert_eq!(config.timeout, Duration::from_secs(30));
+        assert!(config.log_file_path.is_none());
     }
 
     #[test]

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -18,6 +18,9 @@ use crate::core::types::*;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
+use crate::util::logger;
+
+const LOG_TARGET: &str = "contextvm_sdk::transport::server";
 
 /// Configuration for the server transport.
 pub struct NostrServerTransportConfig {
@@ -37,6 +40,8 @@ pub struct NostrServerTransportConfig {
     pub cleanup_interval: Duration,
     /// Session timeout (default: 300s).
     pub session_timeout: Duration,
+    /// Optional log file path used by all SDK modules.
+    pub log_file_path: Option<String>,
 }
 
 impl Default for NostrServerTransportConfig {
@@ -50,6 +55,7 @@ impl Default for NostrServerTransportConfig {
             excluded_capabilities: Vec::new(),
             cleanup_interval: Duration::from_secs(60),
             session_timeout: Duration::from_secs(300),
+            log_file_path: None,
         }
     }
 }
@@ -86,9 +92,26 @@ impl NostrServerTransport {
     where
         T: IntoNostrSigner,
     {
-        let relay_pool = Arc::new(RelayPool::new(signer).await?);
+        logger::set_global_log_file_path(config.log_file_path.clone());
+
+        let relay_pool = Arc::new(RelayPool::new(signer).await.map_err(|error| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!("Failed to initialize relay pool for server transport: {error}"),
+            );
+            error
+        })?);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
+        logger::info_with_target(
+            LOG_TARGET,
+            format!(
+                "Created server transport; relay_count={}; announced={}; encryption_mode={:?}",
+                config.relay_urls.len(),
+                config.is_announced_server,
+                config.encryption_mode,
+            ),
+        );
         Ok(Self {
             base: BaseTransport {
                 relay_pool,
@@ -105,12 +128,42 @@ impl NostrServerTransport {
 
     /// Start listening for incoming requests.
     pub async fn start(&mut self) -> Result<()> {
-        self.base.connect(&self.config.relay_urls).await?;
+        self.base
+            .connect(&self.config.relay_urls)
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!("Failed to connect server transport to relays: {error}"),
+                );
+                error
+            })?;
 
-        let pubkey = self.base.get_public_key().await?;
-        tracing::info!(pubkey = %pubkey.to_hex(), "Server transport started");
+        let pubkey = self.base.get_public_key().await.map_err(|error| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!("Failed to fetch server transport public key: {error}"),
+            );
+            error
+        })?;
+        logger::info_with_target(
+            LOG_TARGET,
+            format!("Server transport started; pubkey={}", pubkey.to_hex()),
+        );
 
-        self.base.subscribe_for_pubkey(&pubkey).await?;
+        self.base
+            .subscribe_for_pubkey(&pubkey)
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!(
+                        "Failed to subscribe server transport for pubkey {}: {error}",
+                        pubkey.to_hex(),
+                    ),
+                );
+                error
+            })?;
 
         // Spawn event loop
         let client = self.base.relay_pool.client().clone();
@@ -151,11 +204,23 @@ impl NostrServerTransport {
                 )
                 .await;
                 if cleaned > 0 {
-                    tracing::info!(cleaned, "Cleaned up inactive sessions");
+                    logger::info_with_target(
+                        LOG_TARGET,
+                        format!("Cleaned up inactive sessions; cleaned={cleaned}"),
+                    );
                 }
             }
         });
 
+        logger::info_with_target(
+            LOG_TARGET,
+            format!(
+                "Server transport loops spawned; relay_count={}; cleanup_interval_secs={}; session_timeout_secs={}",
+                self.config.relay_urls.len(),
+                self.config.cleanup_interval.as_secs(),
+                self.config.session_timeout.as_secs(),
+            ),
+        );
         Ok(())
     }
 
@@ -172,14 +237,24 @@ impl NostrServerTransport {
         let event_to_client = self.event_to_client.read().await;
         let client_pubkey_hex = event_to_client
             .get(event_id)
-            .ok_or_else(|| Error::Other(format!("No client found for event {event_id}")))?
+            .ok_or_else(|| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!("No client found for response correlation; event_id={event_id}"),
+                );
+                Error::Other(format!("No client found for event {event_id}"))
+            })?
             .clone();
         drop(event_to_client);
 
         let sessions = self.sessions.read().await;
-        let session = sessions
-            .get(&client_pubkey_hex)
-            .ok_or_else(|| Error::Other(format!("No session for client {client_pubkey_hex}")))?;
+        let session = sessions.get(&client_pubkey_hex).ok_or_else(|| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!("No session for correlated client; client_pubkey={client_pubkey_hex}"),
+            );
+            Error::Other(format!("No session for client {client_pubkey_hex}"))
+        })?;
 
         // Restore original request ID
         if let Some(original_id) = session.pending_requests.get(event_id) {
@@ -193,11 +268,23 @@ impl NostrServerTransport {
         let is_encrypted = session.is_encrypted;
         drop(sessions);
 
-        let client_pubkey =
-            PublicKey::from_hex(&client_pubkey_hex).map_err(|e| Error::Other(e.to_string()))?;
+        let client_pubkey = PublicKey::from_hex(&client_pubkey_hex).map_err(|e| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!(
+                    "Invalid client pubkey in session map; pubkey={client_pubkey_hex}; error={e}"
+                ),
+            );
+            Error::Other(e.to_string())
+        })?;
 
-        let event_id_parsed =
-            EventId::from_hex(event_id).map_err(|e| Error::Other(e.to_string()))?;
+        let event_id_parsed = EventId::from_hex(event_id).map_err(|e| {
+            logger::error_with_target(
+                LOG_TARGET,
+                format!("Invalid event id while sending response; event_id={event_id}; error={e}"),
+            );
+            Error::Other(e.to_string())
+        })?;
 
         let tags = BaseTransport::create_response_tags(&client_pubkey, &event_id_parsed);
 
@@ -209,7 +296,16 @@ impl NostrServerTransport {
                 tags,
                 Some(is_encrypted),
             )
-            .await?;
+            .await
+            .map_err(|error| {
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!(
+                        "Failed to publish response message; client_pubkey={client_pubkey_hex}; event_id={event_id}; error={error}",
+                    ),
+                );
+                error
+            })?;
 
         // Clean up
         let mut sessions = self.sessions.write().await;
@@ -224,6 +320,12 @@ impl NostrServerTransport {
 
         self.event_to_client.write().await.remove(event_id);
 
+        logger::debug_with_target(
+            LOG_TARGET,
+            format!(
+                "Sent server response and cleaned correlation state; client_pubkey={client_pubkey_hex}; event_id={event_id}; encrypted={is_encrypted}",
+            ),
+        );
         Ok(())
     }
 
@@ -275,7 +377,10 @@ impl NostrServerTransport {
 
         for pubkey in initialized {
             if let Err(e) = self.send_notification(&pubkey, notification, None).await {
-                tracing::error!(client = %pubkey, "Failed to send notification: {e}");
+                logger::error_with_target(
+                    LOG_TARGET,
+                    format!("Failed to send notification; client={pubkey}; error={e}"),
+                );
             }
         }
         Ok(())
@@ -489,14 +594,20 @@ impl NostrServerTransport {
                     || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
                 {
                     if encryption_mode == EncryptionMode::Disabled {
-                        tracing::warn!("Received encrypted message but encryption is disabled");
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            "Received encrypted message but encryption is disabled",
+                        );
                         continue;
                     }
                     // Single-layer NIP-44 decrypt (matches JS/TS SDK)
                     let signer = match client.signer().await {
                         Ok(s) => s,
                         Err(e) => {
-                            tracing::error!("Failed to get signer: {e}");
+                            logger::error_with_target(
+                                LOG_TARGET,
+                                format!("Failed to get signer: {e}"),
+                            );
                             continue;
                         }
                     };
@@ -513,21 +624,30 @@ impl NostrServerTransport {
                                     true,
                                 ),
                                 Err(e) => {
-                                    tracing::error!("Failed to parse inner event: {e}");
+                                    logger::error_with_target(
+                                        LOG_TARGET,
+                                        format!("Failed to parse inner event: {e}"),
+                                    );
                                     continue;
                                 }
                             }
                         }
                         Err(e) => {
-                            tracing::error!("Failed to decrypt: {e}");
+                            logger::error_with_target(
+                                LOG_TARGET,
+                                format!("Failed to decrypt: {e}"),
+                            );
                             continue;
                         }
                     }
                 } else {
                     if encryption_mode == EncryptionMode::Required {
-                        tracing::warn!(
-                            pubkey = %event.pubkey,
-                            "Received unencrypted message but encryption is required"
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            format!(
+                                "Received unencrypted message but encryption is required; pubkey={}",
+                                event.pubkey,
+                            ),
                         );
                         continue;
                     }
@@ -543,7 +663,10 @@ impl NostrServerTransport {
                 let mcp_msg = match serializers::nostr_event_to_mcp_message(&content) {
                     Some(msg) => msg,
                     None => {
-                        tracing::warn!("Invalid MCP message from {sender_pubkey}");
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            format!("Invalid MCP message from {sender_pubkey}"),
+                        );
                         continue;
                     }
                 };
@@ -564,10 +687,11 @@ impl NostrServerTransport {
                         Self::is_capability_excluded(&excluded_capabilities, method, name);
 
                     if !allowed_pubkeys.contains(&sender_pubkey) && !is_excluded {
-                        tracing::warn!(
-                            pubkey = %sender_pubkey,
-                            method = %method,
-                            "Unauthorized request"
+                        logger::warn_with_target(
+                            LOG_TARGET,
+                            format!(
+                                "Unauthorized request; pubkey={sender_pubkey}; method={method}"
+                            ),
                         );
                         continue;
                     }
@@ -647,7 +771,7 @@ impl NostrServerTransport {
                 for event_id in session.event_to_progress_token.keys() {
                     event_map.remove(event_id);
                 }
-                tracing::debug!(client = %pubkey, "Session expired");
+                logger::debug_with_target(LOG_TARGET, format!("Session expired; client={pubkey}"));
                 cleaned += 1;
                 false
             } else {
@@ -882,5 +1006,6 @@ mod tests {
         assert_eq!(config.cleanup_interval, Duration::from_secs(60));
         assert_eq!(config.session_timeout, Duration::from_secs(300));
         assert!(config.server_info.is_none());
+        assert!(config.log_file_path.is_none());
     }
 }

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -1,0 +1,245 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::{OnceLock, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const DEFAULT_TARGET: &str = "contextvm_sdk";
+
+static GLOBAL_LOG_FILE_PATH: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn global_log_file_path_store() -> &'static RwLock<Option<String>> {
+    GLOBAL_LOG_FILE_PATH.get_or_init(|| RwLock::new(None))
+}
+
+fn normalize_path(path: Option<String>) -> Option<String> {
+    path.and_then(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+/// Set the global log file path used when no per-call path is supplied.
+pub fn set_global_log_file_path(file_path: Option<String>) {
+    let normalized = normalize_path(file_path);
+    if let Ok(mut guard) = global_log_file_path_store().write() {
+        *guard = normalized;
+    }
+}
+
+/// Read the currently configured global log file path.
+pub fn get_global_log_file_path() -> Option<String> {
+    global_log_file_path_store()
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
+
+/// Generic log level for string-based logging.
+#[derive(Clone, Copy, Debug)]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    fn as_str(self) -> &'static str {
+        match self {
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+    }
+}
+
+fn timestamp_string() -> String {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0));
+    format!("{}.{:03}", duration.as_secs(), duration.subsec_millis())
+}
+
+fn resolve_file_path(file_path: Option<&str>) -> Option<String> {
+    if let Some(path) = file_path {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    get_global_log_file_path()
+}
+
+fn append_log_to_file(line: &str, file_path: Option<&str>) {
+    let Some(file_path) = resolve_file_path(file_path) else {
+        return;
+    };
+
+    let path = Path::new(file_path.as_str());
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            if let Err(error) = fs::create_dir_all(parent) {
+                eprintln!(
+                    "{}:warn:{}: Failed to create log file parent directory {}: {error}",
+                    timestamp_string(),
+                    DEFAULT_TARGET,
+                    parent.display()
+                );
+                return;
+            }
+        }
+    }
+
+    let mut file = match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(file) => file,
+        Err(error) => {
+            eprintln!(
+                "{}:warn:{}: Failed to open log file {}: {error}",
+                timestamp_string(),
+                DEFAULT_TARGET,
+                path.display()
+            );
+            return;
+        }
+    };
+
+    if let Err(error) = writeln!(file, "{line}") {
+        eprintln!(
+            "{}:warn:{}: Failed to write log entry to {}: {error}",
+            timestamp_string(),
+            DEFAULT_TARGET,
+            path.display()
+        );
+    }
+}
+
+fn emit_console(level: LogLevel, line: &str) {
+    match level {
+        LogLevel::Warn | LogLevel::Error => eprintln!("{line}"),
+        LogLevel::Debug | LogLevel::Info => println!("{line}"),
+    }
+}
+
+fn log_internal(level: LogLevel, target: &str, message: impl AsRef<str>, file_path: Option<&str>) {
+    let line = format!(
+        "{}:{}:{}: {}",
+        timestamp_string(),
+        level.as_str(),
+        target,
+        message.as_ref()
+    );
+
+    emit_console(level, &line);
+    append_log_to_file(&line, file_path);
+}
+
+fn target_or_default(target: Option<&str>) -> &str {
+    target.filter(|t| !t.is_empty()).unwrap_or(DEFAULT_TARGET)
+}
+
+fn log_with_optional_target(
+    level: LogLevel,
+    target: Option<&str>,
+    message: impl AsRef<str>,
+    file_path: Option<&str>,
+) {
+    log_internal(level, target_or_default(target), message, file_path);
+}
+
+/// Log plain text at the given level.
+///
+/// Accepts both `&str` and `String` via `AsRef<str>`.
+pub fn log(level: LogLevel, message: impl AsRef<str>) {
+    log_with_optional_target(level, None, message, None);
+}
+
+/// Log plain text at the given level and optionally append to a file.
+pub fn log_with_file(level: LogLevel, message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_optional_target(level, None, message, file_path);
+}
+
+/// Log plain text at the given level with an explicit module target.
+pub fn log_with_target(level: LogLevel, target: &str, message: impl AsRef<str>) {
+    log_with_optional_target(level, Some(target), message, None);
+}
+
+/// Log plain text at the given level with an explicit target and optional file output.
+pub fn log_with_target_and_file(
+    level: LogLevel,
+    target: &str,
+    message: impl AsRef<str>,
+    file_path: Option<&str>,
+) {
+    log_with_optional_target(level, Some(target), message, file_path);
+}
+
+pub fn debug(message: impl AsRef<str>) {
+    log(LogLevel::Debug, message);
+}
+
+pub fn info(message: impl AsRef<str>) {
+    log(LogLevel::Info, message);
+}
+
+pub fn warn(message: impl AsRef<str>) {
+    log(LogLevel::Warn, message);
+}
+
+pub fn error(message: impl AsRef<str>) {
+    log(LogLevel::Error, message);
+}
+
+pub fn debug_with_file(message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_file(LogLevel::Debug, message, file_path);
+}
+
+pub fn info_with_file(message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_file(LogLevel::Info, message, file_path);
+}
+
+pub fn warn_with_file(message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_file(LogLevel::Warn, message, file_path);
+}
+
+pub fn error_with_file(message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_file(LogLevel::Error, message, file_path);
+}
+
+pub fn debug_with_target(target: &str, message: impl AsRef<str>) {
+    log_with_target(LogLevel::Debug, target, message);
+}
+
+pub fn info_with_target(target: &str, message: impl AsRef<str>) {
+    log_with_target(LogLevel::Info, target, message);
+}
+
+pub fn warn_with_target(target: &str, message: impl AsRef<str>) {
+    log_with_target(LogLevel::Warn, target, message);
+}
+
+pub fn error_with_target(target: &str, message: impl AsRef<str>) {
+    log_with_target(LogLevel::Error, target, message);
+}
+
+pub fn debug_with_target_and_file(target: &str, message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_target_and_file(LogLevel::Debug, target, message, file_path);
+}
+
+pub fn info_with_target_and_file(target: &str, message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_target_and_file(LogLevel::Info, target, message, file_path);
+}
+
+pub fn warn_with_target_and_file(target: &str, message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_target_and_file(LogLevel::Warn, target, message, file_path);
+}
+
+pub fn error_with_target_and_file(target: &str, message: impl AsRef<str>, file_path: Option<&str>) {
+    log_with_target_and_file(LogLevel::Error, target, message, file_path);
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod logger;


### PR DESCRIPTION
This PR introduces a centralised logger module and upgrades transport and rmcp worker error handling so logs are consistent, actionable, and optionally persisted to disk.

Changes/Features:
- Added a centralised logger module with shared debug, info, warn, and error helpers, including target-based logging.
- Added global log file path support so a single startup setting is reused across logger calls.
- Standardised log format to:
`time:level:module_name: main log statement`
- Replaced remaining direct tracing-style logs in rmcp transport and transport layers with the shared logger.

How to use: 
1) Set log file path in startup config.
- NostrServerTransportConfig with log_file_path: Some("/tmp/contextvm-sdk.log".to_string())
- NostrClientTransportConfig with log_file_path: Some("/tmp/contextvm-sdk.log".to_string())

2) Use CLI option in examples.
- cargo run --example gateway -- --log-file <file path>
cargo run --example proxy -- <server_pubkey_hex> --log-file <file path>

3) Use logger helpers for custom module logs.
- logger::info_with_target("my_module", "startup complete")


**Note** : This PR also solves the earlier issue of logger module not being present
<img width="1262" height="298" alt="image" src="https://github.com/user-attachments/assets/2599b8ac-b870-4f03-b32f-332c3d572fa2" />


