### PR TITLE
fix: verify inner event signatures after gift-wrap decryption

### DIFF
--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -264,4 +264,45 @@ mod tests {
         // (it uses an ephemeral key, like the JS SDK)
         assert_ne!(gift_wrap_event.pubkey, sender_keys.public_key());
     }
+
+    /// Regression: gift-wrapped inner events with a tampered pubkey must be
+    /// caught by `Event::verify()`.
+    #[tokio::test]
+    async fn test_forged_inner_event_detected_by_verify() {
+        let real_sender = Keys::generate();
+        let impersonated = Keys::generate();
+        let recipient = Keys::generate();
+
+        let mcp_content = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+
+        // Step 1: build a legitimately signed inner event
+        let inner_event = EventBuilder::new(Kind::Custom(25910), mcp_content)
+            .tag(Tag::public_key(recipient.public_key()))
+            .sign_with_keys(&real_sender)
+            .unwrap();
+
+        // Step 2: tamper the pubkey (keep original, now-invalid, signature)
+        let mut forged_json: serde_json::Value =
+            serde_json::to_value(&inner_event).unwrap();
+        forged_json["pubkey"] =
+            serde_json::Value::String(impersonated.public_key().to_hex());
+        let forged_str = serde_json::to_string(&forged_json).unwrap();
+
+        // Step 3: gift-wrap the forged payload
+        let (gift_wrap, _) =
+            create_simple_gift_wrap(&forged_str, &recipient.public_key()).await;
+
+        // Decrypt + parse both succeed — the forgery is syntactically valid
+        let decrypted = decrypt_gift_wrap_single_layer(&recipient, &gift_wrap)
+            .await
+            .unwrap();
+        let parsed: Event = serde_json::from_str(&decrypted).unwrap();
+        assert_eq!(parsed.pubkey, impersonated.public_key());
+
+        // Signature verification catches the tampered pubkey
+        assert!(
+            parsed.verify().is_err(),
+            "forged inner event must fail signature verification"
+        );
+    }
 }

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -204,6 +204,10 @@ impl NostrClientTransport {
                         Ok(decrypted_json) => {
                             match serde_json::from_str::<Event>(&decrypted_json) {
                                 Ok(inner) => {
+                                    if let Err(e) = inner.verify() {
+                                        tracing::warn!("Inner event signature verification failed: {e}");
+                                        continue;
+                                    }
                                     let e_tag = serializers::get_tag_value(&inner.tags, "e");
                                     (inner.content, inner.pubkey, e_tag)
                                 }

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -506,12 +506,20 @@ impl NostrServerTransport {
                             // Use the INNER event's ID for correlation — the client
                             // registers the inner event ID in its correlation store.
                             match serde_json::from_str::<Event>(&decrypted_json) {
-                                Ok(inner) => (
-                                    inner.content,
-                                    inner.pubkey.to_hex(),
-                                    inner.id.to_hex(),
-                                    true,
-                                ),
+                                Ok(inner) => {
+                                    if let Err(e) = inner.verify() {
+                                        tracing::warn!(
+                                            "Inner event signature verification failed: {e}"
+                                        );
+                                        continue;
+                                    }
+                                    (
+                                        inner.content,
+                                        inner.pubkey.to_hex(),
+                                        inner.id.to_hex(),
+                                        true,
+                                    )
+                                }
                                 Err(e) => {
                                     tracing::error!("Failed to parse inner event: {e}");
                                     continue;


### PR DESCRIPTION
After NIP-44 decrypting a gift-wrapped message, the inner Nostr event's `pubkey` was being trusted as the sender identity without checking the Schnorr signature. This means an attacker could craft a gift wrap containing a forged inner event with someone else's pubkey, effectively impersonating them.

### Fix

Call `Event::verify()` on the decrypted inner event before processing it. This validates both:
- Event ID integrity (SHA256 commitment covers pubkey, content, tags, etc.)
- Schnorr signature against the claimed pubkey

If verification fails, the message is dropped with a warning log. Legitimate messages are unaffected since the encrypt path always produces properly signed inner events.

### Testing

All 105 unit tests + 3 doc tests pass. The new test constructs a real gift-wrap with a tampered inner pubkey and confirms `Event::verify()` catches it.
