### PR TITLE
fix: all Clippy warnings, orphaned doc comment & duplicate constant

### DIFF
--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -33,7 +33,6 @@ pub const RESOURCETEMPLATES_LIST_KIND: u16 = 11319;
 /// Prompts list (addressable, kind 11320)
 pub const PROMPTS_LIST_KIND: u16 = 11320;
 
-pub const KIND_GIFT_WRAP: u16 = 1059;
 /// Nostr tag constants
 pub mod tags {
     /// Public key tag
@@ -69,11 +68,6 @@ pub mod tags {
 
 /// Maximum message size (1MB)
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
-
-/// MCP protocol version string used in initialize responses.
-///
-/// Matches the `protocolVersion` field of the `InitializeResult` JSON-RPC response.
-/// Keep this in sync with the MCP spec and rmcp's `ProtocolVersion::LATEST`.
 
 /// Default LRU cache size for deduplication
 pub const DEFAULT_LRU_SIZE: usize = 5000;
@@ -124,6 +118,19 @@ pub const fn mcp_protocol_version() -> &'static str {
     "2025-11-25"
 }
 
+// Compile-time range checks (NIP-01 kind ranges).
+// Placed at module level so violations are caught in every build, not just `cargo test`.
+const _: () = {
+    // Ephemeral events: 20000 <= kind < 30000
+    assert!(EPHEMERAL_GIFT_WRAP_KIND >= 20000);
+    assert!(EPHEMERAL_GIFT_WRAP_KIND < 30000);
+    assert!(CTXVM_MESSAGES_KIND >= 20000);
+    assert!(CTXVM_MESSAGES_KIND < 30000);
+    // Replaceable events: 10000 <= kind < 20000
+    assert!(RELAY_LIST_METADATA_KIND >= 10000);
+    assert!(RELAY_LIST_METADATA_KIND < 20000);
+};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -156,27 +163,6 @@ mod tests {
             tags::SUPPORT_ENCRYPTION_EPHEMERAL,
             "support_encryption_ephemeral"
         );
-    }
-
-    #[test]
-    fn test_ephemeral_gift_wrap_in_ephemeral_range() {
-        // NIP-01: ephemeral events are 20000 <= kind < 30000
-        assert!(EPHEMERAL_GIFT_WRAP_KIND >= 20000);
-        assert!(EPHEMERAL_GIFT_WRAP_KIND < 30000);
-    }
-
-    #[test]
-    fn test_ctxvm_messages_in_ephemeral_range() {
-        // NIP-01: ephemeral events are 20000 <= kind < 30000
-        assert!(CTXVM_MESSAGES_KIND >= 20000);
-        assert!(CTXVM_MESSAGES_KIND < 30000);
-    }
-
-    #[test]
-    fn test_relay_list_metadata_in_replaceable_range() {
-        // NIP-01: replaceable events are 10000 <= kind < 20000
-        assert!(RELAY_LIST_METADATA_KIND >= 10000);
-        assert!(RELAY_LIST_METADATA_KIND < 20000);
     }
 
     #[test]

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -111,7 +111,7 @@ pub async fn gift_wrap(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::constants::KIND_GIFT_WRAP;
+    use crate::core::constants::GIFT_WRAP_KIND;
 
     use super::*;
 
@@ -153,7 +153,7 @@ mod tests {
             .unwrap();
 
         // Build kind 1059 event
-        let builder = EventBuilder::new(Kind::from(KIND_GIFT_WRAP), encrypted)
+        let builder = EventBuilder::new(Kind::from(GIFT_WRAP_KIND), encrypted)
             .tag(Tag::public_key(*recipient));
 
         let event = builder.sign_with_keys(&ephemeral).unwrap();


### PR DESCRIPTION
## Description

Clean up `src/core/constants.rs` and `src/encryption/mod.rs` so that `cargo clippy --all-targets` reports **zero warnings**.

## Changes

1. Removed duplicate constant

2. Removed orphaned doc comment

3. Converted 6 runtime assertions to compile-time checks

**Before :**
![Screenshot 2026-04-07 183926](https://github.com/user-attachments/assets/41aaa011-6d45-444d-b0e6-b17ce61926c1)


**After :**
![Screenshot 2026-04-07 184034](https://github.com/user-attachments/assets/6017803b-aec3-418d-8316-48a331855636)


## Verification

- `cargo clippy --all-targets` returns 0 warnings (before it was 7)
- `cargo test`  101 passed, 0 failed
