### PR TITLE
fix: route event loops through validated message parsing

### DIFF
--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -8,6 +8,17 @@ pub fn validate_message_size(content: &str) -> bool {
     content.len() <= MAX_MESSAGE_SIZE
 }
 
+/// Validate size and structure, then parse into a [`JsonRpcMessage`].
+pub fn validate_and_parse(content: &str) -> Option<JsonRpcMessage> {
+    if !validate_message_size(content) {
+        tracing::warn!("Message size validation failed: {} bytes", content.len());
+        return None;
+    }
+
+    let value: serde_json::Value = serde_json::from_str(content).ok()?;
+    validate_message(&value)
+}
+
 /// Validate that a JSON value is a well-formed JSON-RPC 2.0 message.
 ///
 /// Checks:
@@ -60,5 +71,31 @@ mod tests {
         assert!(validate_message_size("hello"));
         let big = "x".repeat(MAX_MESSAGE_SIZE + 1);
         assert!(!validate_message_size(&big));
+    }
+
+    #[test]
+    fn test_validate_and_parse_valid_request() {
+        let content = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+        let msg = validate_and_parse(content).unwrap();
+        assert!(msg.is_request());
+        assert_eq!(msg.method(), Some("tools/list"));
+    }
+
+    #[test]
+    fn test_validate_and_parse_rejects_oversized() {
+        let padding = "x".repeat(MAX_MESSAGE_SIZE);
+        let content = format!(r#"{{"jsonrpc":"2.0","id":1,"method":"{}"}}"#, padding);
+        assert!(validate_and_parse(&content).is_none());
+    }
+
+    #[test]
+    fn test_validate_and_parse_rejects_invalid_version() {
+        let content = r#"{"jsonrpc":"1.0","id":1,"method":"test"}"#;
+        assert!(validate_and_parse(content).is_none());
+    }
+
+    #[test]
+    fn test_validate_and_parse_rejects_invalid_json() {
+        assert!(validate_and_parse("not json").is_none());
     }
 }

--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -87,13 +87,7 @@ impl BaseTransport {
 
     /// Convert a Nostr event to an MCP message with validation.
     pub fn convert_event_to_mcp(&self, content: &str) -> Option<JsonRpcMessage> {
-        if !validation::validate_message_size(content) {
-            tracing::warn!("Message size validation failed: {} bytes", content.len());
-            return None;
-        }
-
-        let value: serde_json::Value = serde_json::from_str(content).ok()?;
-        validation::validate_message(&value)
+        validation::validate_and_parse(content)
     }
 
     /// Create a signed Nostr event for an MCP message.

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -14,6 +14,7 @@ use crate::core::constants::*;
 use crate::core::error::{Error, Result};
 use crate::core::serializers;
 use crate::core::types::*;
+use crate::core::validation;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
@@ -244,7 +245,7 @@ impl NostrClientTransport {
 
                 // Parse MCP message
                 if let Some(mcp_msg) =
-                    serializers::nostr_event_to_mcp_message(&actual_event_content)
+                    validation::validate_and_parse(&actual_event_content)
                 {
                     // Clean up pending request
                     if let Some(ref correlated_id) = e_tag {

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -13,8 +13,8 @@ use tokio::sync::RwLock;
 
 use crate::core::constants::*;
 use crate::core::error::{Error, Result};
-use crate::core::serializers;
 use crate::core::types::*;
+use crate::core::validation;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
@@ -548,7 +548,7 @@ impl NostrServerTransport {
                 };
 
                 // Parse MCP message
-                let mcp_msg = match serializers::nostr_event_to_mcp_message(&content) {
+                let mcp_msg = match validation::validate_and_parse(&content) {
                     Some(msg) => msg,
                     None => {
                         tracing::warn!("Invalid MCP message from {sender_pubkey}");


### PR DESCRIPTION
## Problem

Both event loops in `client.rs` and `server.rs` parse incoming messages by calling `serializers::nostr_event_to_mcp_message()` directly. That's just a `serde_json::from_str`  (no size check, no jsonrpc version check)

`BaseTransport::convert_event_to_mcp()` already does both (size ≤ 1MB + jsonrpc 2.0 validation), but neither event loop calls it. The loops are spawned as static async functions without access to `self.base`. 

## Fix
- Extract the validated logic into a standalone `validation::validate_and_parse()` that combines size + structure checks in one call.
- Replace the raw `serializers::nostr_event_to_mcp_message()` call in both event loops with `validation::validate_and_parse()`.
- Simplify `BaseTransport::convert_event_to_mcp()` to delegate to the same function (DRY).
- Remove the now-unused `serializers` import from `server.rs`.


## Testing

All 112 existing tests pass (106 unit + 3 conformance + 3 doc-tests), zero warnings. Four new tests cover the added function directly.
