### PR TITLE
ci: add fmt, clippy, and doc checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,5 +29,14 @@ jobs:
       - name: Test
         run: cargo test --all --all-features
 
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all --all-features -- -D warnings
+
+      - name: Doc check
+        run: cargo doc --no-deps --all-features
+
       - name: Build
         run: cargo build --verbose

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -279,15 +279,12 @@ mod tests {
             .unwrap();
 
         // Step 2: tamper the pubkey (keep original, now-invalid, signature)
-        let mut forged_json: serde_json::Value =
-            serde_json::to_value(&inner_event).unwrap();
-        forged_json["pubkey"] =
-            serde_json::Value::String(impersonated.public_key().to_hex());
+        let mut forged_json: serde_json::Value = serde_json::to_value(&inner_event).unwrap();
+        forged_json["pubkey"] = serde_json::Value::String(impersonated.public_key().to_hex());
         let forged_str = serde_json::to_string(&forged_json).unwrap();
 
         // Step 3: gift-wrap the forged payload
-        let (gift_wrap, _) =
-            create_simple_gift_wrap(&forged_str, &recipient.public_key()).await;
+        let (gift_wrap, _) = create_simple_gift_wrap(&forged_str, &recipient.public_key()).await;
 
         // Decrypt + parse both succeed — the forgery is syntactically valid
         let decrypted = decrypt_gift_wrap_single_layer(&recipient, &gift_wrap)

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -293,7 +293,9 @@ impl NostrClientTransport {
                             match serde_json::from_str::<Event>(&decrypted_json) {
                                 Ok(inner) => {
                                     if let Err(e) = inner.verify() {
-                                        tracing::warn!("Inner event signature verification failed: {e}");
+                                        tracing::warn!(
+                                            "Inner event signature verification failed: {e}"
+                                        );
                                         continue;
                                     }
                                     let e_tag = serializers::get_tag_value(&inner.tags, "e");
@@ -348,9 +350,7 @@ impl NostrClientTransport {
                 }
 
                 // Parse MCP message
-                if let Some(mcp_msg) =
-                    validation::validate_and_parse(&actual_event_content)
-                {
+                if let Some(mcp_msg) = validation::validate_and_parse(&actual_event_content) {
                     // Clean up pending request
                     if let Some(ref correlated_id) = e_tag {
                         pending.write().await.remove(correlated_id.as_str());

--- a/tests/conformance_stateless_mode.rs
+++ b/tests/conformance_stateless_mode.rs
@@ -3,13 +3,9 @@
 use std::time::Duration;
 
 use contextvm_sdk::core::constants::{mcp_protocol_version, INITIALIZE_METHOD};
-use contextvm_sdk::core::types::{
-    EncryptionMode, JsonRpcMessage, JsonRpcRequest,
-};
-use contextvm_sdk::transport::client::{
-    NostrClientTransport, NostrClientTransportConfig,
-};
+use contextvm_sdk::core::types::{EncryptionMode, JsonRpcMessage, JsonRpcRequest};
 use contextvm_sdk::signer;
+use contextvm_sdk::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use tokio::time::timeout;
 
 async fn make_stateless_transport() -> (
@@ -171,5 +167,4 @@ async fn should_handle_statelessly_returns_false_for_other_methods() {
         recv_result.is_err(),
         "non-initialize request should not create a local emulated response"
     );
-
 }

--- a/tests/conformance_wire_format.rs
+++ b/tests/conformance_wire_format.rs
@@ -95,10 +95,11 @@ fn ctxvm_initialize_response_has_kind_e_tag_and_result_protocol_version() {
         params: Some(serde_json::json!({})),
     });
     let recipient_tags = BaseTransport::create_recipient_tags(&server_pk);
-    let request_event = serializers::mcp_to_nostr_event(&init_req, CTXVM_MESSAGES_KIND, recipient_tags)
-        .expect("request event for response correlation should serialize")
-        .sign_with_keys(&client_keys)
-        .expect("sign request event for correlation");
+    let request_event =
+        serializers::mcp_to_nostr_event(&init_req, CTXVM_MESSAGES_KIND, recipient_tags)
+            .expect("request event for response correlation should serialize")
+            .sign_with_keys(&client_keys)
+            .expect("sign request event for correlation");
 
     let init_resp = JsonRpcMessage::Response(JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
@@ -449,8 +450,7 @@ fn ctxvm_server_announcement_has_kind_and_required_tags() {
     assert!(
         event.tags.iter().any(|t| {
             let parts = t.clone().to_vec();
-            parts.len() == 1
-                && parts.first().map(|s| s.as_str()) == Some(tags::SUPPORT_ENCRYPTION)
+            parts.len() == 1 && parts.first().map(|s| s.as_str()) == Some(tags::SUPPORT_ENCRYPTION)
         }),
         "support_encryption must be present as a single-element tag"
     );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,8 +6,8 @@
 
 use rmcp::{
     handler::server::router::tool::ToolRouter, handler::server::wrapper::Parameters, model::*,
-    schemars, tool, tool_handler, tool_router, ClientHandler, RoleServer, ServerHandler,
-    ServiceExt, service::RequestContext,
+    schemars, service::RequestContext, tool, tool_handler, tool_router, ClientHandler, RoleServer,
+    ServerHandler, ServiceExt,
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -102,7 +102,7 @@ impl ServerHandler for DemoServer {
     ) -> Result<ListResourcesResult, ErrorData> {
         Ok(ListResourcesResult {
             resources: vec![
-                RawResource::new("demo://readme", "Demo README".to_string()).no_annotation(),
+                RawResource::new("demo://readme", "Demo README".to_string()).no_annotation()
             ],
             next_cursor: None,
             meta: None,


### PR DESCRIPTION
Adds three missing CI checks:

- cargo fmt --check: enforces consistent formatting
- cargo clippy -D warnings: catches common mistakes and anti-patterns
- cargo doc: verifies doc comments compile cleanly

Also applies cargo fmt to the existing codebase so the new check passes on the current state of main.

All three checks pass after this PR.