### PR TITLE
fix: Client Accepts Plaintext Responses in Required Mode

### DIFF
--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -265,17 +265,32 @@ impl NostrClientTransport {
         pending: Arc<RwLock<HashSet<String>>>,
         server_pubkey: PublicKey,
         tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
-        _encryption_mode: EncryptionMode,
+        encryption_mode: EncryptionMode,
     ) {
         let mut notifications = client.notifications();
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
+                let is_gift_wrap = is_gift_wrap_kind(&event.kind);
+
+                // Enforce mode before decrypt/parse.
+                if violates_encryption_policy(&event.kind, &encryption_mode) {
+                    if is_gift_wrap {
+                        tracing::warn!(
+                            event_id = %event.id.to_hex(),
+                            "Received encrypted response but encryption is disabled"
+                        );
+                    } else {
+                        tracing::warn!(
+                            event_id = %event.id.to_hex(),
+                            "Received unencrypted response but encryption is required"
+                        );
+                    }
+                    continue;
+                }
+
                 // Handle gift-wrapped events
-                let (actual_event_content, actual_pubkey, e_tag) = if event.kind
-                    == Kind::Custom(GIFT_WRAP_KIND)
-                    || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
-                {
+                let (actual_event_content, actual_pubkey, e_tag) = if is_gift_wrap {
                     // Single-layer NIP-44 decrypt (matches JS/TS SDK)
                     let signer = match client.signer().await {
                         Ok(s) => s,
@@ -362,6 +377,20 @@ impl NostrClientTransport {
     }
 }
 
+#[inline]
+fn is_gift_wrap_kind(kind: &Kind) -> bool {
+    *kind == Kind::Custom(GIFT_WRAP_KIND) || *kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
+}
+
+/// Returns `true` when the inbound event kind violates the configured encryption
+/// policy and must be dropped before any further processing.
+#[inline]
+fn violates_encryption_policy(kind: &Kind, mode: &EncryptionMode) -> bool {
+    let is_gift_wrap = is_gift_wrap_kind(kind);
+    (is_gift_wrap && *mode == EncryptionMode::Disabled)
+        || (!is_gift_wrap && *mode == EncryptionMode::Required)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -436,5 +465,79 @@ mod tests {
             params: None,
         });
         assert_eq!(init_notif.method(), Some("notifications/initialized"));
+    }
+
+    #[test]
+    fn test_gift_wrap_kind_detection() {
+        assert!(is_gift_wrap_kind(&Kind::Custom(GIFT_WRAP_KIND)));
+        assert!(is_gift_wrap_kind(&Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)));
+        assert!(!is_gift_wrap_kind(&Kind::Custom(CTXVM_MESSAGES_KIND)));
+    }
+
+    #[test]
+    fn test_required_mode_drops_plaintext() {
+        let plaintext_kind = Kind::Custom(CTXVM_MESSAGES_KIND);
+        assert!(
+            violates_encryption_policy(&plaintext_kind, &EncryptionMode::Required),
+            "Required mode must reject plaintext (non-gift-wrap) events"
+        );
+    }
+
+    #[test]
+    fn test_disabled_mode_drops_encrypted() {
+        assert!(
+            violates_encryption_policy(&Kind::Custom(GIFT_WRAP_KIND), &EncryptionMode::Disabled),
+            "Disabled mode must reject gift-wrap events"
+        );
+        assert!(
+            violates_encryption_policy(
+                &Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND),
+                &EncryptionMode::Disabled
+            ),
+            "Disabled mode must reject ephemeral gift-wrap events"
+        );
+    }
+
+    #[test]
+    fn test_optional_mode_accepts_all() {
+        let plaintext = Kind::Custom(CTXVM_MESSAGES_KIND);
+        let gift_wrap = Kind::Custom(GIFT_WRAP_KIND);
+        let ephemeral = Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND);
+        assert!(!violates_encryption_policy(
+            &plaintext,
+            &EncryptionMode::Optional
+        ));
+        assert!(!violates_encryption_policy(
+            &gift_wrap,
+            &EncryptionMode::Optional
+        ));
+        assert!(!violates_encryption_policy(
+            &ephemeral,
+            &EncryptionMode::Optional
+        ));
+    }
+
+    #[test]
+    fn test_required_mode_accepts_encrypted() {
+        assert!(
+            !violates_encryption_policy(&Kind::Custom(GIFT_WRAP_KIND), &EncryptionMode::Required),
+            "Required mode must accept gift-wrap events"
+        );
+        assert!(
+            !violates_encryption_policy(
+                &Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND),
+                &EncryptionMode::Required
+            ),
+            "Required mode must accept ephemeral gift-wrap events"
+        );
+    }
+
+    #[test]
+    fn test_disabled_mode_accepts_plaintext() {
+        let plaintext = Kind::Custom(CTXVM_MESSAGES_KIND);
+        assert!(
+            !violates_encryption_policy(&plaintext, &EncryptionMode::Disabled),
+            "Disabled mode must accept plaintext events"
+        );
     }
 }


### PR DESCRIPTION
## Problem
Inbound policy enforcement was fail-open in one critical path:
- In `EncryptionMode::Required`, plaintext responses could still be accepted.
- In `EncryptionMode::Disabled`, encrypted gift-wrap traffic was not rejected early.

This breaks the transport contract and creates a downgrade surface for apps that explicitly require encrypted inbound traffic.

## Root cause
`NostrClientTransport::event_loop` accepted an `encryption_mode` parameter but did not enforce it before payload handling.

## Fix
- Use `encryption_mode` directly in `event_loop`.
- Classify inbound event format up front via `is_gift_wrap_kind`.
- Apply fail-closed gating before decrypt/parse:
  - drop encrypted gift-wrap events in `Disabled`
  - drop plaintext events in `Required`
- Keep sender verification and response correlation behavior unchanged.

Closes #21 

## Behavior after this patch
- `Required`: only encrypted inbound responses are accepted.
- `Disabled`: only plaintext inbound responses are accepted.
- `Optional`: unchanged, both formats accepted.

## Verification
- `cargo test -q` passes (107 unit tests + 3 integration tests).
- PoC on unpatched code: plaintext accepted in `Required` mode.
- PoC on patched code: plaintext response is dropped and never forwarded to the client receiver.