### PR TITLE
fix: implement gift-wrap deduplication using LRU cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Optional MCP integration (Rust equivalent to TS @modelcontextprotocol/sdk)
 rmcp = { version = "0.16.0", features = ["server", "client", "macros", "transport-worker"], optional = true }
 
+# LRU cache for gift-wrap (outer event id) deduplication
+lru = "0.12"
+
 [features]
 # Enable rmcp by default while keeping legacy APIs available.
 default = ["rmcp"]

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -4,9 +4,11 @@
 //! kind 25910 events, correlates responses via `e` tag.
 
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use lru::LruCache;
 use nostr_sdk::prelude::*;
 use tokio::sync::RwLock;
 
@@ -59,6 +61,10 @@ pub struct NostrClientTransport {
     server_pubkey: PublicKey,
     /// Pending request event IDs awaiting responses.
     pending_requests: Arc<RwLock<HashSet<String>>>,
+    /// Outer gift-wrap event IDs successfully decrypted and verified (inner `verify()`).
+    /// Duplicate outer ids are skipped before decrypt; ids are inserted only after success
+    /// so failed decrypt/verify can be retried on redelivery.
+    seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     /// Channel for receiving processed MCP messages from the event loop.
     message_tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
     message_rx: Option<tokio::sync::mpsc::UnboundedReceiver<JsonRpcMessage>>,
@@ -91,6 +97,9 @@ impl NostrClientTransport {
             error
         })?);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let seen_gift_wrap_ids = Arc::new(Mutex::new(LruCache::new(
+            NonZeroUsize::new(DEFAULT_LRU_SIZE).expect("DEFAULT_LRU_SIZE must be non-zero"),
+        )));
 
         tracing::info!(
             target: LOG_TARGET,
@@ -108,6 +117,7 @@ impl NostrClientTransport {
             config,
             server_pubkey,
             pending_requests: Arc::new(RwLock::new(HashSet::new())),
+            seen_gift_wrap_ids,
             message_tx: tx,
             message_rx: Some(rx),
         })
@@ -160,9 +170,18 @@ impl NostrClientTransport {
         let server_pubkey = self.server_pubkey;
         let tx = self.message_tx.clone();
         let encryption_mode = self.config.encryption_mode;
+        let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
 
         tokio::spawn(async move {
-            Self::event_loop(client, pending, server_pubkey, tx, encryption_mode).await;
+            Self::event_loop(
+                client,
+                pending,
+                server_pubkey,
+                tx,
+                encryption_mode,
+                seen_gift_wrap_ids,
+            )
+            .await;
         });
 
         tracing::info!(
@@ -266,6 +285,7 @@ impl NostrClientTransport {
         server_pubkey: PublicKey,
         tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
         encryption_mode: EncryptionMode,
+        seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     ) {
         let mut notifications = client.notifications();
 
@@ -291,6 +311,20 @@ impl NostrClientTransport {
 
                 // Handle gift-wrapped events
                 let (actual_event_content, actual_pubkey, e_tag) = if is_gift_wrap {
+                    {
+                        let guard = match seen_gift_wrap_ids.lock() {
+                            Ok(g) => g,
+                            Err(poisoned) => poisoned.into_inner(),
+                        };
+                        if guard.contains(&event.id) {
+                            tracing::debug!(
+                                target: LOG_TARGET,
+                                event_id = %event.id.to_hex(),
+                                "Skipping duplicate gift-wrap (outer id)"
+                            );
+                            continue;
+                        }
+                    }
                     // Single-layer NIP-44 decrypt (matches JS/TS SDK)
                     let signer = match client.signer().await {
                         Ok(s) => s,
@@ -312,6 +346,13 @@ impl NostrClientTransport {
                                             "Inner event signature verification failed: {e}"
                                         );
                                         continue;
+                                    }
+                                    {
+                                        let mut guard = match seen_gift_wrap_ids.lock() {
+                                            Ok(g) => g,
+                                            Err(poisoned) => poisoned.into_inner(),
+                                        };
+                                        guard.put(event.id, ());
                                     }
                                     let e_tag = serializers::get_tag_value(&inner.tags, "e");
                                     (inner.content, inner.pubkey, e_tag)

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -5,9 +5,11 @@
 //! server announcements.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use lru::LruCache;
 use nostr_sdk::prelude::*;
 use tokio::sync::RwLock;
 
@@ -69,6 +71,10 @@ pub struct NostrServerTransport {
     sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
     /// Reverse lookup: event_id → client_pubkey_hex
     event_to_client: Arc<RwLock<HashMap<String, String>>>,
+    /// Outer gift-wrap event IDs successfully decrypted and verified (inner `verify()`).
+    /// Duplicate outer ids are skipped before decrypt; ids are inserted only after success
+    /// so failed decrypt/verify can be retried on redelivery.
+    seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     /// Channel for incoming MCP messages (consumed by the MCP server).
     message_tx: tokio::sync::mpsc::UnboundedSender<IncomingRequest>,
     message_rx: Option<tokio::sync::mpsc::UnboundedReceiver<IncomingRequest>>,
@@ -104,6 +110,9 @@ impl NostrServerTransport {
             error
         })?);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let seen_gift_wrap_ids = Arc::new(Mutex::new(LruCache::new(
+            NonZeroUsize::new(DEFAULT_LRU_SIZE).expect("DEFAULT_LRU_SIZE must be non-zero"),
+        )));
 
         tracing::info!(
             target: LOG_TARGET,
@@ -121,6 +130,7 @@ impl NostrServerTransport {
             config,
             sessions: Arc::new(RwLock::new(HashMap::new())),
             event_to_client: Arc::new(RwLock::new(HashMap::new())),
+            seen_gift_wrap_ids,
             message_tx: tx,
             message_rx: Some(rx),
         })
@@ -175,6 +185,7 @@ impl NostrServerTransport {
         let allowed = self.config.allowed_public_keys.clone();
         let excluded = self.config.excluded_capabilities.clone();
         let encryption_mode = self.config.encryption_mode;
+        let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
 
         tokio::spawn(async move {
             Self::event_loop(
@@ -185,6 +196,7 @@ impl NostrServerTransport {
                 allowed,
                 excluded,
                 encryption_mode,
+                seen_gift_wrap_ids,
             )
             .await;
         });
@@ -585,6 +597,7 @@ impl NostrServerTransport {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn event_loop(
         client: Arc<Client>,
         sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
@@ -593,6 +606,7 @@ impl NostrServerTransport {
         allowed_pubkeys: Vec<String>,
         excluded_capabilities: Vec<CapabilityExclusion>,
         encryption_mode: EncryptionMode,
+        seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     ) {
         let mut notifications = client.notifications();
 
@@ -610,6 +624,20 @@ impl NostrServerTransport {
                             "Received encrypted message but encryption is disabled"
                         );
                         continue;
+                    }
+                    {
+                        let guard = match seen_gift_wrap_ids.lock() {
+                            Ok(g) => g,
+                            Err(poisoned) => poisoned.into_inner(),
+                        };
+                        if guard.contains(&event.id) {
+                            tracing::debug!(
+                                target: LOG_TARGET,
+                                event_id = %event.id.to_hex(),
+                                "Skipping duplicate gift-wrap (outer id)"
+                            );
+                            continue;
+                        }
                     }
                     // Single-layer NIP-44 decrypt (matches JS/TS SDK)
                     let signer = match client.signer().await {
@@ -635,6 +663,13 @@ impl NostrServerTransport {
                                             "Inner event signature verification failed: {e}"
                                         );
                                         continue;
+                                    }
+                                    {
+                                        let mut guard = match seen_gift_wrap_ids.lock() {
+                                            Ok(g) => g,
+                                            Err(poisoned) => poisoned.into_inner(),
+                                        };
+                                        guard.put(event.id, ());
                                     }
                                     (
                                         inner.content,


### PR DESCRIPTION
Fixes #25 

DEFAULT_LRU_SIZE was defined in constants but never wired up. Without deduplication, the same gift-wrapped event could be decrypted and dispatched multiple times if relays delivered duplicates -- matching a known gap vs the TS SDK which tracks seen outer event ids.

Adds an LRU cache to both client and server transports tracking outer gift-wrap event ids. The check runs before decryption -- if the outer id is already seen, the event is skipped. The id is only inserted after successful decrypt and inner event verification, so failed decrypts can be retried on redelivery.

