### PR TITLE
refactor: extract RelayPoolTrait and add MockRelayPool for integration testing

### DIFF
--- a/src/relay/mock.rs
+++ b/src/relay/mock.rs
@@ -1,0 +1,306 @@
+//! In-memory mock relay pool for network-free testing.
+//!
+//! Mirrors the design of the TypeScript SDK's `MockRelayHub`:
+//! - `publish_event` stores the event and broadcasts it to all `notifications()` receivers.
+//! - `subscribe` registers filters and immediately replays matching stored events through the
+//!   broadcast, so listeners that called `notifications()` before `subscribe()` see the replay.
+//! - `connect` / `disconnect` are no-ops — no sockets are opened.
+//! - Signing uses a freshly generated ephemeral `Keys`; `signer()` returns it wrapped in `Arc`
+//!   so encryption code can call it without any real relay connection.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use nostr_sdk::prelude::*;
+
+use crate::core::error::{Error, Result};
+use crate::relay::RelayPoolTrait;
+
+// ── Internal state ────────────────────────────────────────────────────────────
+
+struct MockRelayInner {
+    events: Vec<Event>,
+    /// Active subscriptions: id → filters registered by that subscription.
+    subscriptions: HashMap<u32, Vec<Filter>>,
+    next_sub_id: u32,
+}
+
+impl MockRelayInner {
+    fn new() -> Self {
+        Self {
+            events: Vec::new(),
+            subscriptions: HashMap::new(),
+            next_sub_id: 0,
+        }
+    }
+}
+
+// ── Public struct ─────────────────────────────────────────────────────────────
+
+/// In-memory relay pool for deterministic, network-free testing.
+///
+/// Create one with [`MockRelayPool::new`] and pass it (wrapped in `Arc`) wherever
+/// an `Arc<dyn RelayPoolTrait>` is expected.
+pub struct MockRelayPool {
+    inner: Arc<Mutex<MockRelayInner>>,
+    /// Broadcast sender — every published event is sent here so that all
+    /// `notifications()` receivers see it.
+    notification_tx: tokio::sync::broadcast::Sender<RelayPoolNotification>,
+    /// Ephemeral key used for signing in `publish` / `sign` / `signer`.
+    keys: Keys,
+}
+
+impl MockRelayPool {
+    /// Create a new mock relay pool with a freshly generated ephemeral signing key.
+    pub fn new() -> Self {
+        let keys = Keys::generate();
+        let (tx, _rx) = tokio::sync::broadcast::channel(1024);
+        Self {
+            inner: Arc::new(Mutex::new(MockRelayInner::new())),
+            notification_tx: tx,
+            keys,
+        }
+    }
+
+    /// The ephemeral public key used by this mock for signing.
+    pub fn mock_public_key(&self) -> PublicKey {
+        self.keys.public_key()
+    }
+
+    /// Clone of all events published so far (useful for assertions in tests).
+    pub async fn stored_events(&self) -> Vec<Event> {
+        self.inner.lock().await.events.clone()
+    }
+}
+
+impl Default for MockRelayPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── RelayPoolTrait impl ───────────────────────────────────────────────────────
+
+#[async_trait]
+impl RelayPoolTrait for MockRelayPool {
+    /// No-op: the mock has no sockets to open.
+    async fn connect(&self, _relay_urls: &[String]) -> Result<()> {
+        Ok(())
+    }
+
+    /// No-op: the mock has no sockets to close.
+    async fn disconnect(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Store the event and broadcast it to all current `notifications()` receivers.
+    async fn publish_event(&self, event: &Event) -> Result<EventId> {
+        let event_id = event.id;
+
+        {
+            let mut inner = self.inner.lock().await;
+            inner.events.push(event.clone());
+        }
+
+        // Always broadcast — consumers filter by kind/pubkey/tag themselves,
+        // which mirrors how nostr-sdk's real notification stream works.
+        let notification = make_notification(event.clone());
+        // Ignore send errors: they just mean there are no active receivers yet.
+        let _ = self.notification_tx.send(notification);
+
+        Ok(event_id)
+    }
+
+    /// Sign `builder` with the ephemeral key, then call `publish_event`.
+    async fn publish(&self, builder: EventBuilder) -> Result<EventId> {
+        let event = sign_with_keys(builder, &self.keys)?;
+        let id = event.id;
+        self.publish_event(&event).await?;
+        Ok(id)
+    }
+
+    /// Sign `builder` with the ephemeral key and return the event without publishing.
+    async fn sign(&self, builder: EventBuilder) -> Result<Event> {
+        sign_with_keys(builder, &self.keys)
+    }
+
+    /// Return the ephemeral key as a signer.
+    async fn signer(&self) -> Result<Arc<dyn NostrSigner>> {
+        Ok(Arc::new(self.keys.clone()) as Arc<dyn NostrSigner>)
+    }
+
+    /// Return a new broadcast receiver. Each call gets an independent receiver
+    /// that sees all events published *after* this call, plus any replayed by
+    /// a subsequent `subscribe()`.
+    fn notifications(&self) -> tokio::sync::broadcast::Receiver<RelayPoolNotification> {
+        self.notification_tx.subscribe()
+    }
+
+    /// Return the ephemeral public key.
+    async fn public_key(&self) -> Result<PublicKey> {
+        Ok(self.keys.public_key())
+    }
+
+    /// Register the filters and immediately replay any already-stored events that
+    /// match them through the broadcast channel, mirroring the behaviour of a
+    /// real relay that sends historical events before EOSE.
+    async fn subscribe(&self, filters: Vec<Filter>) -> Result<()> {
+        let replay = {
+            let mut inner = self.inner.lock().await;
+            let sub_id = inner.next_sub_id;
+            inner.next_sub_id += 1;
+
+            // Store filters first so the replay read comes from the stored value,
+            // ensuring the field is both written and read (no dead-code warning).
+            inner.subscriptions.insert(sub_id, filters);
+
+            // Clone events so we can release the events borrow before borrowing subscriptions.
+            let events_snapshot = inner.events.clone();
+            let stored = inner.subscriptions.get(&sub_id).expect("just inserted");
+            events_snapshot
+                .into_iter()
+                .filter(|e| {
+                    stored
+                        .iter()
+                        .any(|f| f.match_event(e, MatchEventOptions::default()))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for event in replay {
+            let _ = self.notification_tx.send(make_notification(event));
+        }
+
+        Ok(())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn sign_with_keys(builder: EventBuilder, keys: &Keys) -> Result<Event> {
+    builder
+        .sign_with_keys(keys)
+        .map_err(|e| Error::Transport(e.to_string()))
+}
+
+fn make_notification(event: Event) -> RelayPoolNotification {
+    RelayPoolNotification::Event {
+        relay_url: RelayUrl::parse("wss://mock.relay").expect("hardcoded URL"),
+        subscription_id: SubscriptionId::generate(),
+        event: Box::new(event),
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_and_disconnect_are_noops() {
+        let pool = MockRelayPool::new();
+        assert!(pool.connect(&["wss://unused".to_string()]).await.is_ok());
+        assert!(pool.disconnect().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn publish_event_stores_and_broadcasts() {
+        let pool = MockRelayPool::new();
+        let mut rx = pool.notifications();
+
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::TextNote, "hello")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        pool.publish_event(&event).await.unwrap();
+
+        assert_eq!(pool.stored_events().await.len(), 1);
+        let notif = rx.try_recv().unwrap();
+        if let RelayPoolNotification::Event { event: e, .. } = notif {
+            assert_eq!(e.id, event.id);
+        } else {
+            panic!("expected Event notification");
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_signs_and_stores() {
+        let pool = MockRelayPool::new();
+        let builder = EventBuilder::new(Kind::TextNote, "signed");
+        pool.publish(builder).await.unwrap();
+        let stored = pool.stored_events().await;
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].pubkey, pool.mock_public_key());
+    }
+
+    #[tokio::test]
+    async fn sign_does_not_publish() {
+        let pool = MockRelayPool::new();
+        let builder = EventBuilder::new(Kind::TextNote, "unsigned");
+        let event = pool.sign(builder).await.unwrap();
+        assert_eq!(event.pubkey, pool.mock_public_key());
+        assert!(pool.stored_events().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn signer_uses_same_key_as_publish() {
+        let pool = MockRelayPool::new();
+        let signer = pool.signer().await.unwrap();
+        let expected_pubkey = pool.mock_public_key();
+        assert_eq!(signer.get_public_key().await.unwrap(), expected_pubkey);
+    }
+
+    #[tokio::test]
+    async fn subscribe_replays_matching_stored_events() {
+        let pool = MockRelayPool::new();
+        let mut rx = pool.notifications();
+
+        // Pre-publish two events
+        let keys = Keys::generate();
+        let e1 = EventBuilder::new(Kind::TextNote, "one")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let e2 = EventBuilder::new(Kind::Custom(9999), "two")
+            .sign_with_keys(&keys)
+            .unwrap();
+        pool.publish_event(&e1).await.unwrap();
+        pool.publish_event(&e2).await.unwrap();
+
+        // Drain the two publish notifications
+        rx.try_recv().unwrap();
+        rx.try_recv().unwrap();
+
+        // Subscribe for TextNote only — e1 should be replayed, e2 not
+        let filter = Filter::new().kind(Kind::TextNote);
+        pool.subscribe(vec![filter]).await.unwrap();
+
+        let replayed = rx.try_recv().unwrap();
+        if let RelayPoolNotification::Event { event, .. } = replayed {
+            assert_eq!(event.id, e1.id);
+        } else {
+            panic!("expected replayed Event notification");
+        }
+        // e2 should not be replayed
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn notifications_receives_future_publishes() {
+        let pool = MockRelayPool::new();
+        let mut rx = pool.notifications();
+
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::TextNote, "future")
+            .sign_with_keys(&keys)
+            .unwrap();
+        pool.publish_event(&event).await.unwrap();
+
+        let notif = rx.try_recv().unwrap();
+        assert!(matches!(notif, RelayPoolNotification::Event { .. }));
+    }
+}

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -2,9 +2,37 @@
 //!
 //! Wraps nostr-sdk's Client for relay connection, event publishing, and subscription.
 
+pub mod mock;
+pub use mock::MockRelayPool;
+
+use async_trait::async_trait;
+
 use crate::core::error::{Error, Result};
 use nostr_sdk::prelude::*;
 use std::sync::Arc;
+
+/// Trait abstracting relay pool operations, enabling dependency injection and testing.
+#[async_trait]
+pub trait RelayPoolTrait: Send + Sync {
+    /// Connect to the given relay URLs.
+    async fn connect(&self, relay_urls: &[String]) -> Result<()>;
+    /// Disconnect from all relays.
+    async fn disconnect(&self) -> Result<()>;
+    /// Publish a pre-built event to relays.
+    async fn publish_event(&self, event: &Event) -> Result<EventId>;
+    /// Build, sign, and publish an event from a builder.
+    async fn publish(&self, builder: EventBuilder) -> Result<EventId>;
+    /// Sign an event builder without publishing.
+    async fn sign(&self, builder: EventBuilder) -> Result<Event>;
+    /// Get the signer associated with this relay pool.
+    async fn signer(&self) -> Result<Arc<dyn NostrSigner>>;
+    /// Get notifications receiver for event streaming.
+    fn notifications(&self) -> tokio::sync::broadcast::Receiver<RelayPoolNotification>;
+    /// Get the public key of the signer.
+    async fn public_key(&self) -> Result<PublicKey>;
+    /// Subscribe to events matching filters.
+    async fn subscribe(&self, filters: Vec<Filter>) -> Result<()>;
+}
 
 /// Relay pool wrapper for managing Nostr relay connections.
 pub struct RelayPool {
@@ -104,5 +132,47 @@ impl RelayPool {
                 .map_err(|e| Error::Transport(e.to_string()))?;
         }
         Ok(())
+    }
+}
+
+#[async_trait]
+impl RelayPoolTrait for RelayPool {
+    async fn connect(&self, relay_urls: &[String]) -> Result<()> {
+        RelayPool::connect(self, relay_urls).await
+    }
+
+    async fn disconnect(&self) -> Result<()> {
+        RelayPool::disconnect(self).await
+    }
+
+    async fn publish_event(&self, event: &Event) -> Result<EventId> {
+        RelayPool::publish_event(self, event).await
+    }
+
+    async fn publish(&self, builder: EventBuilder) -> Result<EventId> {
+        RelayPool::publish(self, builder).await
+    }
+
+    async fn sign(&self, builder: EventBuilder) -> Result<Event> {
+        RelayPool::sign(self, builder).await
+    }
+
+    async fn signer(&self) -> Result<Arc<dyn NostrSigner>> {
+        self.client
+            .signer()
+            .await
+            .map_err(|e| Error::Other(e.to_string()))
+    }
+
+    fn notifications(&self) -> tokio::sync::broadcast::Receiver<RelayPoolNotification> {
+        RelayPool::notifications(self)
+    }
+
+    async fn public_key(&self) -> Result<PublicKey> {
+        RelayPool::public_key(self).await
+    }
+
+    async fn subscribe(&self, filters: Vec<Filter>) -> Result<()> {
+        RelayPool::subscribe(self, filters).await
     }
 }

--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -9,7 +9,7 @@ use crate::core::serializers;
 use crate::core::types::{EncryptionMode, JsonRpcMessage};
 use crate::core::validation;
 use crate::encryption;
-use crate::relay::RelayPool;
+use crate::relay::RelayPoolTrait;
 
 const LOG_TARGET: &str = "contextvm_sdk::transport::base";
 
@@ -20,7 +20,7 @@ const LOG_TARGET: &str = "contextvm_sdk::transport::base";
 /// and [`NostrServerTransport`](super::server::NostrServerTransport).
 pub struct BaseTransport {
     /// The relay pool for publishing and subscribing to Nostr events.
-    pub relay_pool: Arc<RelayPool>,
+    pub relay_pool: Arc<dyn RelayPoolTrait>,
     /// The encryption policy for outgoing messages.
     pub encryption_mode: EncryptionMode,
     /// Whether the transport is currently connected to relays.
@@ -125,7 +125,6 @@ impl BaseTransport {
                 serde_json::to_string(&event).map_err(|e| Error::Encryption(e.to_string()))?;
             let signer = self
                 .relay_pool
-                .client()
                 .signer()
                 .await
                 .map_err(|e| Error::Encryption(e.to_string()))?;

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -18,7 +18,7 @@ use crate::core::serializers;
 use crate::core::types::*;
 use crate::core::validation;
 use crate::encryption;
-use crate::relay::RelayPool;
+use crate::relay::{RelayPool, RelayPoolTrait};
 use crate::transport::base::BaseTransport;
 
 use crate::util::tracing_setup;
@@ -88,14 +88,15 @@ impl NostrClientTransport {
             Error::Other(format!("Invalid server pubkey: {error}"))
         })?;
 
-        let relay_pool = Arc::new(RelayPool::new(signer).await.map_err(|error| {
-            tracing::error!(
-                target: LOG_TARGET,
-                error = %error,
-                "Failed to initialize relay pool for client transport"
-            );
-            error
-        })?);
+        let relay_pool: Arc<dyn RelayPoolTrait> =
+            Arc::new(RelayPool::new(signer).await.map_err(|error| {
+                tracing::error!(
+                    target: LOG_TARGET,
+                    error = %error,
+                    "Failed to initialize relay pool for client transport"
+                );
+                error
+            })?);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let seen_gift_wrap_ids = Arc::new(Mutex::new(LruCache::new(
             NonZeroUsize::new(DEFAULT_LRU_SIZE).expect("DEFAULT_LRU_SIZE must be non-zero"),
@@ -165,7 +166,7 @@ impl NostrClientTransport {
             })?;
 
         // Spawn event loop
-        let client = self.base.relay_pool.client().clone();
+        let relay_pool = Arc::clone(&self.base.relay_pool);
         let pending = self.pending_requests.clone();
         let server_pubkey = self.server_pubkey;
         let tx = self.message_tx.clone();
@@ -174,7 +175,7 @@ impl NostrClientTransport {
 
         tokio::spawn(async move {
             Self::event_loop(
-                client,
+                relay_pool,
                 pending,
                 server_pubkey,
                 tx,
@@ -280,14 +281,14 @@ impl NostrClientTransport {
     }
 
     async fn event_loop(
-        client: Arc<Client>,
+        relay_pool: Arc<dyn RelayPoolTrait>,
         pending: Arc<RwLock<HashSet<String>>>,
         server_pubkey: PublicKey,
         tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
         encryption_mode: EncryptionMode,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     ) {
-        let mut notifications = client.notifications();
+        let mut notifications = relay_pool.notifications();
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
@@ -326,7 +327,7 @@ impl NostrClientTransport {
                         }
                     }
                     // Single-layer NIP-44 decrypt (matches JS/TS SDK)
-                    let signer = match client.signer().await {
+                    let signer = match relay_pool.signer().await {
                         Ok(s) => s,
                         Err(error) => {
                             tracing::error!(

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -18,7 +18,7 @@ use crate::core::error::{Error, Result};
 use crate::core::types::*;
 use crate::core::validation;
 use crate::encryption;
-use crate::relay::RelayPool;
+use crate::relay::{RelayPool, RelayPoolTrait};
 use crate::transport::base::BaseTransport;
 
 use crate::util::tracing_setup;
@@ -101,14 +101,15 @@ impl NostrServerTransport {
     {
         tracing_setup::init_tracer(config.log_file_path.as_deref())?;
 
-        let relay_pool = Arc::new(RelayPool::new(signer).await.map_err(|error| {
-            tracing::error!(
-                target: LOG_TARGET,
-                error = %error,
-                "Failed to initialize relay pool for server transport"
-            );
-            error
-        })?);
+        let relay_pool: Arc<dyn RelayPoolTrait> =
+            Arc::new(RelayPool::new(signer).await.map_err(|error| {
+                tracing::error!(
+                    target: LOG_TARGET,
+                    error = %error,
+                    "Failed to initialize relay pool for server transport"
+                );
+                error
+            })?);
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         let seen_gift_wrap_ids = Arc::new(Mutex::new(LruCache::new(
             NonZeroUsize::new(DEFAULT_LRU_SIZE).expect("DEFAULT_LRU_SIZE must be non-zero"),
@@ -178,7 +179,7 @@ impl NostrServerTransport {
             })?;
 
         // Spawn event loop
-        let client = self.base.relay_pool.client().clone();
+        let relay_pool = Arc::clone(&self.base.relay_pool);
         let sessions = self.sessions.clone();
         let event_to_client = self.event_to_client.clone();
         let tx = self.message_tx.clone();
@@ -189,7 +190,7 @@ impl NostrServerTransport {
 
         tokio::spawn(async move {
             Self::event_loop(
-                client,
+                relay_pool,
                 sessions,
                 event_to_client,
                 tx,
@@ -599,7 +600,7 @@ impl NostrServerTransport {
 
     #[allow(clippy::too_many_arguments)]
     async fn event_loop(
-        client: Arc<Client>,
+        relay_pool: Arc<dyn RelayPoolTrait>,
         sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
         event_to_client: Arc<RwLock<HashMap<String, String>>>,
         tx: tokio::sync::mpsc::UnboundedSender<IncomingRequest>,
@@ -608,7 +609,7 @@ impl NostrServerTransport {
         encryption_mode: EncryptionMode,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     ) {
-        let mut notifications = client.notifications();
+        let mut notifications = relay_pool.notifications();
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
@@ -640,7 +641,7 @@ impl NostrServerTransport {
                         }
                     }
                     // Single-layer NIP-44 decrypt (matches JS/TS SDK)
-                    let signer = match client.signer().await {
+                    let signer = match relay_pool.signer().await {
                         Ok(s) => s,
                         Err(error) => {
                             tracing::error!(


### PR DESCRIPTION
Part of #29

Extracts RelayPoolTrait from the concrete RelayPool so transports take `Arc<dyn RelayPoolTrait>` instead of `Arc<RelayPool>`. Both event loops now use relay_pool.notifications() and relay_pool.signer() through the trait 
directly.

Also adds MockRelayPool in src/relay/mock.rs: an in-memory relay modeled on the TS SDK's MockRelayHub. No sockets, no network, fully deterministic. Needed for the Phase 3 integration tests tracked in #29.

