### PR TITLE
Add LRU event dedup in transport loops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ nostr-sdk = { version = "0.43", features = ["nip59"] }
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+lru = "0.16"
 
 # Optional MCP integration (Rust equivalent to TS @modelcontextprotocol/sdk)
 rmcp = { version = "0.16.0", features = ["server", "client", "macros", "transport-worker"], optional = true }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -127,6 +127,7 @@ mod tests {
             excluded_capabilities: vec![],
             cleanup_interval: Duration::from_secs(120),
             session_timeout: Duration::from_secs(600),
+            seen_event_cache_size: 4096,
             log_file_path: None,
         };
 
@@ -142,6 +143,7 @@ mod tests {
         );
         assert!(config.nostr_config.is_announced_server);
         assert_eq!(config.nostr_config.allowed_public_keys.len(), 1);
+        assert_eq!(config.nostr_config.seen_event_cache_size, 4096);
         assert!(
             config
                 .nostr_config

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -112,6 +112,7 @@ mod tests {
             encryption_mode: EncryptionMode::Required,
             is_stateless: true,
             timeout: Duration::from_secs(60),
+            seen_event_cache_size: 2048,
             log_file_path: None,
         };
 
@@ -128,6 +129,7 @@ mod tests {
         );
         assert!(config.nostr_config.is_stateless);
         assert_eq!(config.nostr_config.timeout, Duration::from_secs(60));
+        assert_eq!(config.nostr_config.seen_event_cache_size, 2048);
     }
 
     #[test]

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -18,6 +18,7 @@ use crate::core::validation;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
+use crate::transport::dedup::EventDeduplicator;
 
 use crate::util::tracing_setup;
 
@@ -35,6 +36,8 @@ pub struct NostrClientTransportConfig {
     pub is_stateless: bool,
     /// Response timeout (default: 30s).
     pub timeout: Duration,
+    /// Size of LRU seen-event cache used for inbound deduplication (default: 5000).
+    pub seen_event_cache_size: usize,
     /// Optional log file path. Logs always go to stdout and are also appended here when set.
     pub log_file_path: Option<String>,
 }
@@ -47,6 +50,7 @@ impl Default for NostrClientTransportConfig {
             encryption_mode: EncryptionMode::Optional,
             is_stateless: false,
             timeout: Duration::from_secs(30),
+            seen_event_cache_size: DEFAULT_LRU_SIZE,
             log_file_path: None,
         }
     }
@@ -160,14 +164,24 @@ impl NostrClientTransport {
         let server_pubkey = self.server_pubkey;
         let tx = self.message_tx.clone();
         let encryption_mode = self.config.encryption_mode;
+        let seen_event_cache_size = self.config.seen_event_cache_size;
 
         tokio::spawn(async move {
-            Self::event_loop(client, pending, server_pubkey, tx, encryption_mode).await;
+            Self::event_loop(
+                client,
+                pending,
+                server_pubkey,
+                tx,
+                encryption_mode,
+                seen_event_cache_size,
+            )
+            .await;
         });
 
         tracing::info!(
             target: LOG_TARGET,
             relay_count = self.config.relay_urls.len(),
+            seen_event_cache_size = self.config.seen_event_cache_size,
             "Client transport event loop spawned"
         );
         Ok(())
@@ -266,11 +280,32 @@ impl NostrClientTransport {
         server_pubkey: PublicKey,
         tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
         encryption_mode: EncryptionMode,
+        seen_event_cache_size: usize,
     ) {
         let mut notifications = client.notifications();
+        let mut deduplicator = EventDeduplicator::new(seen_event_cache_size);
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
+                let event_id = event.id.to_hex();
+                if deduplicator.should_drop(&event_id) {
+                    let dedup_hits = deduplicator.duplicate_hits();
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        event_id = %event_id,
+                        dedup_hits = dedup_hits,
+                        "Skipping duplicate event"
+                    );
+                    if dedup_hits.is_multiple_of(100) {
+                        tracing::info!(
+                            target: LOG_TARGET,
+                            dedup_hits = dedup_hits,
+                            "Client inbound deduplication suppressed duplicate events"
+                        );
+                    }
+                    continue;
+                }
+
                 let is_gift_wrap = is_gift_wrap_kind(&event.kind);
 
                 // Enforce mode before decrypt/parse.

--- a/src/transport/dedup.rs
+++ b/src/transport/dedup.rs
@@ -1,0 +1,130 @@
+use lru::LruCache;
+use std::num::NonZeroUsize;
+
+const MIN_CACHE_SIZE: usize = 1;
+
+/// Bounded seen-event cache used to suppress duplicate Nostr events.
+pub(crate) struct SeenEventCache {
+    cache: LruCache<String, ()>,
+}
+
+impl SeenEventCache {
+    pub(crate) fn new(capacity: usize) -> Self {
+        let bounded_capacity = capacity.max(MIN_CACHE_SIZE);
+        let cache_size =
+            NonZeroUsize::new(bounded_capacity).expect("bounded seen-event cache size is non-zero");
+        Self {
+            cache: LruCache::new(cache_size),
+        }
+    }
+
+    /// Returns true when the event was already seen.
+    pub(crate) fn is_duplicate(&mut self, event_id: &str) -> bool {
+        self.cache.put(event_id.to_string(), ()).is_some()
+    }
+}
+
+/// State holder used by transport loops to suppress duplicate events and track hits.
+pub(crate) struct EventDeduplicator {
+    seen: SeenEventCache,
+    duplicate_hits: u64,
+}
+
+impl EventDeduplicator {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            seen: SeenEventCache::new(capacity),
+            duplicate_hits: 0,
+        }
+    }
+
+    /// Returns true when processing should stop because this event is a duplicate.
+    pub(crate) fn should_drop(&mut self, event_id: &str) -> bool {
+        if self.seen.is_duplicate(event_id) {
+            self.duplicate_hits = self.duplicate_hits.saturating_add(1);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn duplicate_hits(&self) -> u64 {
+        self.duplicate_hits
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EventDeduplicator, SeenEventCache};
+
+    #[test]
+    fn test_seen_event_cache_detects_duplicates() {
+        let mut cache = SeenEventCache::new(16);
+        assert!(!cache.is_duplicate("event-1"));
+        assert!(cache.is_duplicate("event-1"));
+    }
+
+    #[test]
+    fn test_seen_event_cache_evicts_oldest_when_full() {
+        let mut cache = SeenEventCache::new(2);
+        assert!(!cache.is_duplicate("a"));
+        assert!(!cache.is_duplicate("b"));
+        assert!(!cache.is_duplicate("c"));
+
+        // "a" was the least-recently seen and should have been evicted.
+        assert!(!cache.is_duplicate("a"));
+    }
+
+    #[test]
+    fn test_seen_event_cache_minimum_capacity_is_one() {
+        let mut cache = SeenEventCache::new(0);
+        assert!(!cache.is_duplicate("x"));
+        assert!(!cache.is_duplicate("y"));
+        assert!(!cache.is_duplicate("x"));
+    }
+
+    #[test]
+    fn test_event_deduplicator_counts_duplicate_hits() {
+        let mut deduplicator = EventDeduplicator::new(8);
+
+        assert!(!deduplicator.should_drop("evt-1"));
+        assert_eq!(deduplicator.duplicate_hits(), 0);
+
+        assert!(deduplicator.should_drop("evt-1"));
+        assert_eq!(deduplicator.duplicate_hits(), 1);
+
+        assert!(deduplicator.should_drop("evt-1"));
+        assert_eq!(deduplicator.duplicate_hits(), 2);
+    }
+
+    #[test]
+    fn test_event_deduplicator_simulates_multi_relay_duplicate_delivery() {
+        let mut deduplicator = EventDeduplicator::new(16);
+        let deliveries = [
+            ("relay-a", "event-1"),
+            ("relay-b", "event-1"),
+            ("relay-c", "event-1"),
+            ("relay-a", "event-2"),
+            ("relay-b", "event-2"),
+        ];
+
+        let mut forwarded = Vec::new();
+        for (_, event_id) in deliveries {
+            if !deduplicator.should_drop(event_id) {
+                forwarded.push(event_id);
+            }
+        }
+
+        assert_eq!(forwarded, vec!["event-1", "event-2"]);
+        assert_eq!(deduplicator.duplicate_hits(), 3);
+    }
+
+    #[test]
+    fn test_event_deduplicator_blocks_recent_replay_within_window() {
+        let mut deduplicator = EventDeduplicator::new(4);
+
+        assert!(!deduplicator.should_drop("replay-me"));
+        assert!(deduplicator.should_drop("replay-me"));
+        assert_eq!(deduplicator.duplicate_hits(), 1);
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod base;
 pub mod client;
+mod dedup;
 pub mod server;
 
 pub use client::{NostrClientTransport, NostrClientTransportConfig};

--- a/src/transport/server.rs
+++ b/src/transport/server.rs
@@ -18,6 +18,7 @@ use crate::core::validation;
 use crate::encryption;
 use crate::relay::RelayPool;
 use crate::transport::base::BaseTransport;
+use crate::transport::dedup::EventDeduplicator;
 
 use crate::util::tracing_setup;
 
@@ -41,6 +42,8 @@ pub struct NostrServerTransportConfig {
     pub cleanup_interval: Duration,
     /// Session timeout (default: 300s).
     pub session_timeout: Duration,
+    /// Size of LRU seen-event cache used for inbound deduplication (default: 5000).
+    pub seen_event_cache_size: usize,
     /// Optional log file path. Logs always go to stdout and are also appended here when set.
     pub log_file_path: Option<String>,
 }
@@ -56,6 +59,7 @@ impl Default for NostrServerTransportConfig {
             excluded_capabilities: Vec::new(),
             cleanup_interval: Duration::from_secs(60),
             session_timeout: Duration::from_secs(300),
+            seen_event_cache_size: DEFAULT_LRU_SIZE,
             log_file_path: None,
         }
     }
@@ -85,6 +89,13 @@ pub struct IncomingRequest {
     pub event_id: String,
     /// Whether the original message was encrypted.
     pub is_encrypted: bool,
+}
+
+struct EventLoopSettings {
+    allowed_pubkeys: Vec<String>,
+    excluded_capabilities: Vec<CapabilityExclusion>,
+    encryption_mode: EncryptionMode,
+    seen_event_cache_size: usize,
 }
 
 impl NostrServerTransport {
@@ -172,21 +183,15 @@ impl NostrServerTransport {
         let sessions = self.sessions.clone();
         let event_to_client = self.event_to_client.clone();
         let tx = self.message_tx.clone();
-        let allowed = self.config.allowed_public_keys.clone();
-        let excluded = self.config.excluded_capabilities.clone();
-        let encryption_mode = self.config.encryption_mode;
+        let settings = EventLoopSettings {
+            allowed_pubkeys: self.config.allowed_public_keys.clone(),
+            excluded_capabilities: self.config.excluded_capabilities.clone(),
+            encryption_mode: self.config.encryption_mode,
+            seen_event_cache_size: self.config.seen_event_cache_size,
+        };
 
         tokio::spawn(async move {
-            Self::event_loop(
-                client,
-                sessions,
-                event_to_client,
-                tx,
-                allowed,
-                excluded,
-                encryption_mode,
-            )
-            .await;
+            Self::event_loop(client, sessions, event_to_client, tx, settings).await;
         });
 
         // Spawn session cleanup
@@ -220,6 +225,7 @@ impl NostrServerTransport {
             relay_count = self.config.relay_urls.len(),
             cleanup_interval_secs = self.config.cleanup_interval.as_secs(),
             session_timeout_secs = self.config.session_timeout.as_secs(),
+            seen_event_cache_size = self.config.seen_event_cache_size,
             "Server transport loops spawned"
         );
         Ok(())
@@ -590,19 +596,37 @@ impl NostrServerTransport {
         sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
         event_to_client: Arc<RwLock<HashMap<String, String>>>,
         tx: tokio::sync::mpsc::UnboundedSender<IncomingRequest>,
-        allowed_pubkeys: Vec<String>,
-        excluded_capabilities: Vec<CapabilityExclusion>,
-        encryption_mode: EncryptionMode,
+        settings: EventLoopSettings,
     ) {
         let mut notifications = client.notifications();
+        let mut deduplicator = EventDeduplicator::new(settings.seen_event_cache_size);
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
+                let outer_event_id = event.id.to_hex();
+                if deduplicator.should_drop(&outer_event_id) {
+                    let dedup_hits = deduplicator.duplicate_hits();
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        event_id = %outer_event_id,
+                        dedup_hits = dedup_hits,
+                        "Skipping duplicate event"
+                    );
+                    if dedup_hits.is_multiple_of(100) {
+                        tracing::info!(
+                            target: LOG_TARGET,
+                            dedup_hits = dedup_hits,
+                            "Server inbound deduplication suppressed duplicate events"
+                        );
+                    }
+                    continue;
+                }
+
                 let (content, sender_pubkey, event_id, is_encrypted) = if event.kind
                     == Kind::Custom(GIFT_WRAP_KIND)
                     || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND)
                 {
-                    if encryption_mode == EncryptionMode::Disabled {
+                    if settings.encryption_mode == EncryptionMode::Disabled {
                         tracing::warn!(
                             target: LOG_TARGET,
                             event_id = %event.id.to_hex(),
@@ -663,7 +687,7 @@ impl NostrServerTransport {
                         }
                     }
                 } else {
-                    if encryption_mode == EncryptionMode::Required {
+                    if settings.encryption_mode == EncryptionMode::Required {
                         tracing::warn!(
                             target: LOG_TARGET,
                             sender_pubkey = %event.pubkey.to_hex(),
@@ -693,7 +717,7 @@ impl NostrServerTransport {
                 };
 
                 // Authorization check
-                if !allowed_pubkeys.is_empty() {
+                if !settings.allowed_pubkeys.is_empty() {
                     let method = mcp_msg.method().unwrap_or("");
                     let name = match &mcp_msg {
                         JsonRpcMessage::Request(r) => r
@@ -705,9 +729,9 @@ impl NostrServerTransport {
                     };
 
                     let is_excluded =
-                        Self::is_capability_excluded(&excluded_capabilities, method, name);
+                        Self::is_capability_excluded(&settings.excluded_capabilities, method, name);
 
-                    if !allowed_pubkeys.contains(&sender_pubkey) && !is_excluded {
+                    if !settings.allowed_pubkeys.contains(&sender_pubkey) && !is_excluded {
                         tracing::warn!(
                             target: LOG_TARGET,
                             sender_pubkey = %sender_pubkey,
@@ -1019,6 +1043,15 @@ mod tests {
         assert_eq!(config.encryption_mode, EncryptionMode::Optional);
     }
 
+    #[test]
+    fn test_custom_seen_event_cache_size() {
+        let config = NostrServerTransportConfig {
+            seen_event_cache_size: 2049,
+            ..Default::default()
+        };
+        assert_eq!(config.seen_event_cache_size, 2049);
+    }
+
     // ── Config defaults ─────────────────────────────────────────
 
     #[test]
@@ -1030,6 +1063,7 @@ mod tests {
         assert!(config.excluded_capabilities.is_empty());
         assert_eq!(config.cleanup_interval, Duration::from_secs(60));
         assert_eq!(config.session_timeout, Duration::from_secs(300));
+        assert_eq!(config.seen_event_cache_size, DEFAULT_LRU_SIZE);
         assert!(config.server_info.is_none());
         assert!(config.log_file_path.is_none());
     }

--- a/tests/conformance_stateless_mode.rs
+++ b/tests/conformance_stateless_mode.rs
@@ -21,6 +21,7 @@ async fn make_stateless_transport() -> (
         encryption_mode: EncryptionMode::Optional,
         is_stateless: true,
         timeout: Duration::from_secs(1),
+        seen_event_cache_size: 64,
         log_file_path: None,
     };
 


### PR DESCRIPTION
This PR adds inbound event deduplication to both transport event loops using a bounded LRU seen-event cache.

## Description

`DEFAULT_LRU_SIZE` already existed, but dedup was not implemented. In multi-relay setups, the same Nostr event can be delivered multiple times. Without dedup, duplicates and replayed events are processed repeatedly.

## What is changed

- Added `transport/dedup.rs` with `EventDeduplicator` (LRU-backed seen-event cache + duplicate hit counter).
- Added dedup gates in both client and server inbound event loops, before decrypt/parse work.
- Added `seen_event_cache_size` to both transport configs (default: `DEFAULT_LRU_SIZE`, 5000).
- Added periodic duplicate-hit logging for observability.
- Added tests for duplicate detection, eviction behavior, replay-window behavior, and config wiring.

## Validation

- `cargo check`
- `cargo test --lib`
- `cargo test --tests --no-run`
- `cargo test --examples --no-run`
