### PR TITLE
 refactor: extract ClientCorrelationStore and ServerEventRouteStore into dedicated modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,12 @@ pub use core::types::{
 };
 pub use discovery::ServerAnnouncement;
 pub use relay::RelayPool;
-pub use transport::client::{NostrClientTransport, NostrClientTransportConfig};
-pub use transport::server::{IncomingRequest, NostrServerTransport, NostrServerTransportConfig};
+pub use transport::client::{
+    ClientCorrelationStore, NostrClientTransport, NostrClientTransportConfig,
+};
+pub use transport::server::{
+    IncomingRequest, NostrServerTransport, NostrServerTransportConfig, ServerEventRouteStore,
+};
 
 #[cfg(feature = "rmcp")]
 pub use rmcp;

--- a/src/transport/client/correlation_store.rs
+++ b/src/transport/client/correlation_store.rs
@@ -1,0 +1,74 @@
+//! Client-side correlation store for tracking pending request event IDs.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+/// Tracks pending request event IDs awaiting responses on the client side.
+#[derive(Clone)]
+pub struct ClientCorrelationStore {
+    pending_requests: Arc<RwLock<HashSet<String>>>,
+}
+
+impl Default for ClientCorrelationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClientCorrelationStore {
+    pub fn new() -> Self {
+        Self {
+            pending_requests: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+
+    pub async fn register(&self, event_id: String) {
+        self.pending_requests.write().await.insert(event_id);
+    }
+
+    pub async fn contains(&self, event_id: &str) -> bool {
+        self.pending_requests.read().await.contains(event_id)
+    }
+
+    pub async fn remove(&self, event_id: &str) {
+        self.pending_requests.write().await.remove(event_id);
+    }
+
+    pub async fn clear(&self) {
+        self.pending_requests.write().await.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn remove_nonexistent_is_noop() {
+        let store = ClientCorrelationStore::new();
+        store.remove("nonexistent").await;
+        assert!(!store.contains("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn contains_after_clear() {
+        let store = ClientCorrelationStore::new();
+        store.register("e1".into()).await;
+        store.register("e2".into()).await;
+        assert!(store.contains("e1").await);
+        store.clear().await;
+        assert!(!store.contains("e1").await);
+        assert!(!store.contains("e2").await);
+    }
+
+    #[tokio::test]
+    async fn register_and_remove_roundtrip() {
+        let store = ClientCorrelationStore::new();
+        store.register("e1".into()).await;
+        assert!(store.contains("e1").await);
+        store.remove("e1").await;
+        assert!(!store.contains("e1").await);
+    }
+}

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -3,14 +3,16 @@
 //! Connects to a remote MCP server over Nostr. Sends JSON-RPC requests as
 //! kind 25910 events, correlates responses via `e` tag.
 
-use std::collections::HashSet;
+pub mod correlation_store;
+
+pub use correlation_store::ClientCorrelationStore;
+
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
-use tokio::sync::RwLock;
 
 use crate::core::constants::*;
 use crate::core::error::{Error, Result};
@@ -60,7 +62,7 @@ pub struct NostrClientTransport {
     config: NostrClientTransportConfig,
     server_pubkey: PublicKey,
     /// Pending request event IDs awaiting responses.
-    pending_requests: Arc<RwLock<HashSet<String>>>,
+    pending_requests: ClientCorrelationStore,
     /// Outer gift-wrap event IDs successfully decrypted and verified (inner `verify()`).
     /// Duplicate outer ids are skipped before decrypt; ids are inserted only after success
     /// so failed decrypt/verify can be retried on redelivery.
@@ -117,7 +119,7 @@ impl NostrClientTransport {
             },
             config,
             server_pubkey,
-            pending_requests: Arc::new(RwLock::new(HashSet::new())),
+            pending_requests: ClientCorrelationStore::new(),
             seen_gift_wrap_ids,
             message_tx: tx,
             message_rx: Some(rx),
@@ -238,10 +240,7 @@ impl NostrClientTransport {
             })?;
 
         if matches!(message, JsonRpcMessage::Request(_)) {
-            self.pending_requests
-                .write()
-                .await
-                .insert(event_id.to_hex());
+            self.pending_requests.register(event_id.to_hex()).await;
         }
 
         tracing::debug!(
@@ -282,7 +281,7 @@ impl NostrClientTransport {
 
     async fn event_loop(
         relay_pool: Arc<dyn RelayPoolTrait>,
-        pending: Arc<RwLock<HashSet<String>>>,
+        pending: ClientCorrelationStore,
         server_pubkey: PublicKey,
         tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
         encryption_mode: EncryptionMode,
@@ -395,7 +394,7 @@ impl NostrClientTransport {
 
                 // Correlate response
                 if let Some(ref correlated_id) = e_tag {
-                    let is_pending = pending.read().await.contains(correlated_id.as_str());
+                    let is_pending = pending.contains(correlated_id.as_str()).await;
                     if !is_pending {
                         tracing::warn!(
                             target: LOG_TARGET,
@@ -410,7 +409,7 @@ impl NostrClientTransport {
                 if let Some(mcp_msg) = validation::validate_and_parse(&actual_event_content) {
                     // Clean up pending request
                     if let Some(ref correlated_id) = e_tag {
-                        pending.write().await.remove(correlated_id.as_str());
+                        pending.remove(correlated_id.as_str()).await;
                     }
                     let _ = tx.send(mcp_msg);
                 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,5 +7,5 @@ pub mod base;
 pub mod client;
 pub mod server;
 
-pub use client::{NostrClientTransport, NostrClientTransportConfig};
-pub use server::{NostrServerTransport, NostrServerTransportConfig};
+pub use client::{ClientCorrelationStore, NostrClientTransport, NostrClientTransportConfig};
+pub use server::{NostrServerTransport, NostrServerTransportConfig, ServerEventRouteStore};

--- a/src/transport/server/correlation_store.rs
+++ b/src/transport/server/correlation_store.rs
@@ -1,0 +1,114 @@
+//! Server-side event route store for mapping event IDs to client public keys.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+/// Maps event IDs to client public keys for response routing on the server side.
+#[derive(Clone)]
+pub struct ServerEventRouteStore {
+    event_to_client: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl Default for ServerEventRouteStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServerEventRouteStore {
+    pub fn new() -> Self {
+        Self {
+            event_to_client: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn register(&self, event_id: String, client_pubkey: String) {
+        self.event_to_client
+            .write()
+            .await
+            .insert(event_id, client_pubkey);
+    }
+
+    /// Returns the client public key for the given event ID without removing it.
+    pub async fn get(&self, event_id: &str) -> Option<String> {
+        self.event_to_client.read().await.get(event_id).cloned()
+    }
+
+    /// Removes and returns the client public key for the given event ID.
+    pub async fn pop(&self, event_id: &str) -> Option<String> {
+        self.event_to_client.write().await.remove(event_id)
+    }
+
+    /// Removes all routes for a given client public key.
+    pub async fn remove_for_client(&self, client_pubkey: &str) {
+        self.event_to_client
+            .write()
+            .await
+            .retain(|_, v| v != client_pubkey);
+    }
+
+    pub async fn clear(&self) {
+        self.event_to_client.write().await.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pop_on_empty_returns_none() {
+        let store = ServerEventRouteStore::new();
+        assert!(store.pop("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_returns_without_removing() {
+        let store = ServerEventRouteStore::new();
+        store.register("e1".into(), "pk1".into()).await;
+        assert_eq!(store.get("e1").await.as_deref(), Some("pk1"));
+        assert_eq!(store.get("e1").await.as_deref(), Some("pk1"));
+    }
+
+    #[tokio::test]
+    async fn pop_removes_entry() {
+        let store = ServerEventRouteStore::new();
+        store.register("e1".into(), "pk1".into()).await;
+        assert_eq!(store.pop("e1").await.as_deref(), Some("pk1"));
+        assert!(store.pop("e1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_for_client_only_removes_matching() {
+        let store = ServerEventRouteStore::new();
+        store.register("e1".into(), "pk1".into()).await;
+        store.register("e2".into(), "pk2".into()).await;
+        store.register("e3".into(), "pk1".into()).await;
+
+        store.remove_for_client("pk1").await;
+
+        assert!(store.get("e1").await.is_none());
+        assert!(store.get("e3").await.is_none());
+        assert_eq!(store.get("e2").await.as_deref(), Some("pk2"));
+    }
+
+    #[tokio::test]
+    async fn remove_for_client_noop_when_no_match() {
+        let store = ServerEventRouteStore::new();
+        store.register("e1".into(), "pk1".into()).await;
+        store.remove_for_client("pk_other").await;
+        assert_eq!(store.get("e1").await.as_deref(), Some("pk1"));
+    }
+
+    #[tokio::test]
+    async fn clear_empties_store() {
+        let store = ServerEventRouteStore::new();
+        store.register("e1".into(), "pk1".into()).await;
+        store.register("e2".into(), "pk2".into()).await;
+        store.clear().await;
+        assert!(store.get("e1").await.is_none());
+        assert!(store.get("e2").await.is_none());
+    }
+}

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -4,6 +4,10 @@
 //! sessions, handles request/response correlation, and optionally publishes
 //! server announcements.
 
+pub mod correlation_store;
+
+pub use correlation_store::ServerEventRouteStore;
+
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -70,7 +74,7 @@ pub struct NostrServerTransport {
     /// Client sessions: client_pubkey_hex → ClientSession
     sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
     /// Reverse lookup: event_id → client_pubkey_hex
-    event_to_client: Arc<RwLock<HashMap<String, String>>>,
+    event_routes: ServerEventRouteStore,
     /// Outer gift-wrap event IDs successfully decrypted and verified (inner `verify()`).
     /// Duplicate outer ids are skipped before decrypt; ids are inserted only after success
     /// so failed decrypt/verify can be retried on redelivery.
@@ -130,7 +134,7 @@ impl NostrServerTransport {
             },
             config,
             sessions: Arc::new(RwLock::new(HashMap::new())),
-            event_to_client: Arc::new(RwLock::new(HashMap::new())),
+            event_routes: ServerEventRouteStore::new(),
             seen_gift_wrap_ids,
             message_tx: tx,
             message_rx: Some(rx),
@@ -181,7 +185,7 @@ impl NostrServerTransport {
         // Spawn event loop
         let relay_pool = Arc::clone(&self.base.relay_pool);
         let sessions = self.sessions.clone();
-        let event_to_client = self.event_to_client.clone();
+        let event_routes = self.event_routes.clone();
         let tx = self.message_tx.clone();
         let allowed = self.config.allowed_public_keys.clone();
         let excluded = self.config.excluded_capabilities.clone();
@@ -192,7 +196,7 @@ impl NostrServerTransport {
             Self::event_loop(
                 relay_pool,
                 sessions,
-                event_to_client,
+                event_routes,
                 tx,
                 allowed,
                 excluded,
@@ -204,7 +208,7 @@ impl NostrServerTransport {
 
         // Spawn session cleanup
         let sessions_cleanup = self.sessions.clone();
-        let event_to_client_cleanup = self.event_to_client.clone();
+        let event_routes_cleanup = self.event_routes.clone();
         let cleanup_interval = self.config.cleanup_interval;
         let session_timeout = self.config.session_timeout;
 
@@ -214,7 +218,7 @@ impl NostrServerTransport {
                 interval.tick().await;
                 let cleaned = Self::cleanup_sessions(
                     &sessions_cleanup,
-                    &event_to_client_cleanup,
+                    &event_routes_cleanup,
                     session_timeout,
                 )
                 .await;
@@ -242,25 +246,20 @@ impl NostrServerTransport {
     pub async fn close(&mut self) -> Result<()> {
         self.base.disconnect().await?;
         self.sessions.write().await.clear();
-        self.event_to_client.write().await.clear();
+        self.event_routes.clear().await;
         Ok(())
     }
 
     /// Send a response back to the client that sent the original request.
     pub async fn send_response(&self, event_id: &str, mut response: JsonRpcMessage) -> Result<()> {
-        let event_to_client = self.event_to_client.read().await;
-        let client_pubkey_hex = event_to_client
-            .get(event_id)
-            .ok_or_else(|| {
-                tracing::error!(
-                    target: LOG_TARGET,
-                    event_id = %event_id,
-                    "No client found for response correlation"
-                );
-                Error::Other(format!("No client found for event {event_id}"))
-            })?
-            .clone();
-        drop(event_to_client);
+        let client_pubkey_hex = self.event_routes.get(event_id).await.ok_or_else(|| {
+            tracing::error!(
+                target: LOG_TARGET,
+                event_id = %event_id,
+                "No client found for response correlation"
+            );
+            Error::Other(format!("No client found for event {event_id}"))
+        })?;
 
         let sessions = self.sessions.read().await;
         let session = sessions.get(&client_pubkey_hex).ok_or_else(|| {
@@ -326,7 +325,9 @@ impl NostrServerTransport {
                 error
             })?;
 
-        // Clean up
+        // Clean up only after successful send
+        self.event_routes.pop(event_id).await;
+
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(&client_pubkey_hex) {
             // Clean up progress token
@@ -336,8 +337,6 @@ impl NostrServerTransport {
             session.pending_requests.remove(event_id);
         }
         drop(sessions);
-
-        self.event_to_client.write().await.remove(event_id);
 
         tracing::debug!(
             target: LOG_TARGET,
@@ -602,7 +601,7 @@ impl NostrServerTransport {
     async fn event_loop(
         relay_pool: Arc<dyn RelayPoolTrait>,
         sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
-        event_to_client: Arc<RwLock<HashMap<String, String>>>,
+        event_routes: ServerEventRouteStore,
         tx: tokio::sync::mpsc::UnboundedSender<IncomingRequest>,
         allowed_pubkeys: Vec<String>,
         excluded_capabilities: Vec<CapabilityExclusion>,
@@ -768,10 +767,9 @@ impl NostrServerTransport {
                     session
                         .pending_requests
                         .insert(event_id.clone(), original_id);
-                    event_to_client
-                        .write()
-                        .await
-                        .insert(event_id.clone(), sender_pubkey.clone());
+                    event_routes
+                        .register(event_id.clone(), sender_pubkey.clone())
+                        .await;
 
                     // Track progress token
                     if let Some(token) = req
@@ -812,22 +810,17 @@ impl NostrServerTransport {
 
     async fn cleanup_sessions(
         sessions: &RwLock<HashMap<String, ClientSession>>,
-        event_to_client: &RwLock<HashMap<String, String>>,
+        event_routes: &ServerEventRouteStore,
         timeout: Duration,
     ) -> usize {
         let mut sessions_w = sessions.write().await;
-        let mut event_map = event_to_client.write().await;
         let mut cleaned = 0;
+        let mut stale_event_ids = Vec::new();
 
         sessions_w.retain(|pubkey, session| {
             if session.last_activity.elapsed() > timeout {
-                // Clean up reverse mappings
-                for event_id in session.pending_requests.keys() {
-                    event_map.remove(event_id);
-                }
-                for event_id in session.event_to_progress_token.keys() {
-                    event_map.remove(event_id);
-                }
+                stale_event_ids.extend(session.pending_requests.keys().cloned());
+                stale_event_ids.extend(session.event_to_progress_token.keys().cloned());
                 tracing::debug!(
                     target: LOG_TARGET,
                     client_pubkey = %pubkey,
@@ -839,6 +832,11 @@ impl NostrServerTransport {
                 true
             }
         });
+        drop(sessions_w);
+
+        for event_id in &stale_event_ids {
+            event_routes.pop(event_id).await;
+        }
 
         cleaned
     }
@@ -872,7 +870,7 @@ mod tests {
     #[tokio::test]
     async fn test_cleanup_sessions_removes_expired() {
         let sessions = Arc::new(RwLock::new(HashMap::new()));
-        let event_to_client = Arc::new(RwLock::new(HashMap::new()));
+        let event_routes = ServerEventRouteStore::new();
 
         // Insert a session with an old activity time
         let mut session = ClientSession::new(false);
@@ -883,15 +881,14 @@ mod tests {
             .write()
             .await
             .insert("pubkey1".to_string(), session);
-        event_to_client
-            .write()
-            .await
-            .insert("evt1".to_string(), "pubkey1".to_string());
+        event_routes
+            .register("evt1".to_string(), "pubkey1".to_string())
+            .await;
 
         // With a long timeout, nothing should be cleaned
         let cleaned = NostrServerTransport::cleanup_sessions(
             &sessions,
-            &event_to_client,
+            &event_routes,
             Duration::from_secs(300),
         )
         .await;
@@ -902,26 +899,26 @@ mod tests {
         thread::sleep(Duration::from_millis(5));
         let cleaned = NostrServerTransport::cleanup_sessions(
             &sessions,
-            &event_to_client,
+            &event_routes,
             Duration::from_millis(1),
         )
         .await;
         assert_eq!(cleaned, 1);
         assert!(sessions.read().await.is_empty());
-        assert!(event_to_client.read().await.is_empty());
+        assert!(event_routes.pop("evt1").await.is_none());
     }
 
     #[tokio::test]
     async fn test_cleanup_preserves_active_sessions() {
         let sessions = Arc::new(RwLock::new(HashMap::new()));
-        let event_to_client = Arc::new(RwLock::new(HashMap::new()));
+        let event_routes = ServerEventRouteStore::new();
 
         let session = ClientSession::new(false);
         sessions.write().await.insert("active".to_string(), session);
 
         let cleaned = NostrServerTransport::cleanup_sessions(
             &sessions,
-            &event_to_client,
+            &event_routes,
             Duration::from_secs(300),
         )
         .await;


### PR DESCRIPTION
The correlation and session logic was embedded inside the transport event loops, making it impossible to unit test in isolation. This was blocking the Phase 1 and Phase 2 conformance test porting tracked 
in #14 and #18.

Extracts two standalone modules from the transport layer:

ClientCorrelationStore (src/transport/client/correlation_store.rs) wraps the pending_requests HashSet with register, contains, remove, and clear methods. Replaces the inline Arc<RwLock<HashSet<String>>> 
in NostrClientTransport.

ServerEventRouteStore (src/transport/server/correlation_store.rs)
Wraps the event_to_client HashMap with register, get, pop, 
remove_for_client, and clear methods. Replaces the inline Arc<RwLock<HashMap<String, String>>> in NostrServerTransport.

send_response now uses get before the send attempt and only calls pop after a successful send, so the route is preserved on failure. cleanup_sessions was also fixed to collect specific event IDs rather than using the broad remove_for_client, avoiding a potential race between session expiry and new session creation.

Both modules have unit tests. 141 tests passing.


Part of #36, #14  and #18 