### PR TITLE
refactor: enrich correlation stores, add SessionStore and port Phase 1 / 2 conformance tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,8 @@ pub use transport::client::{
     ClientCorrelationStore, NostrClientTransport, NostrClientTransportConfig,
 };
 pub use transport::server::{
-    IncomingRequest, NostrServerTransport, NostrServerTransportConfig, ServerEventRouteStore,
+    IncomingRequest, NostrServerTransport, NostrServerTransportConfig, RouteEntry,
+    ServerEventRouteStore, SessionSnapshot, SessionStore,
 };
 
 #[cfg(feature = "rmcp")]

--- a/src/transport/client/correlation_store.rs
+++ b/src/transport/client/correlation_store.rs
@@ -1,14 +1,14 @@
 //! Client-side correlation store for tracking pending request event IDs.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-/// Tracks pending request event IDs awaiting responses on the client side.
+/// Tracks pending request event IDs and their original request IDs on the client side.
 #[derive(Clone)]
 pub struct ClientCorrelationStore {
-    pending_requests: Arc<RwLock<HashSet<String>>>,
+    pending_requests: Arc<RwLock<HashMap<String, serde_json::Value>>>,
 }
 
 impl Default for ClientCorrelationStore {
@@ -20,20 +20,39 @@ impl Default for ClientCorrelationStore {
 impl ClientCorrelationStore {
     pub fn new() -> Self {
         Self {
-            pending_requests: Arc::new(RwLock::new(HashSet::new())),
+            pending_requests: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
-    pub async fn register(&self, event_id: String) {
-        self.pending_requests.write().await.insert(event_id);
+    /// Register a pending request with its original JSON-RPC request ID.
+    pub async fn register(&self, event_id: String, original_id: serde_json::Value) {
+        self.pending_requests
+            .write()
+            .await
+            .insert(event_id, original_id);
     }
 
     pub async fn contains(&self, event_id: &str) -> bool {
-        self.pending_requests.read().await.contains(event_id)
+        self.pending_requests.read().await.contains_key(event_id)
     }
 
-    pub async fn remove(&self, event_id: &str) {
-        self.pending_requests.write().await.remove(event_id);
+    /// Remove a pending request. Returns `true` if the key existed.
+    pub async fn remove(&self, event_id: &str) -> bool {
+        self.pending_requests
+            .write()
+            .await
+            .remove(event_id)
+            .is_some()
+    }
+
+    /// Retrieve the original request ID for a given event ID without removing it.
+    pub async fn get_original_id(&self, event_id: &str) -> Option<serde_json::Value> {
+        self.pending_requests.read().await.get(event_id).cloned()
+    }
+
+    /// Number of pending requests currently tracked.
+    pub async fn count(&self) -> usize {
+        self.pending_requests.read().await.len()
     }
 
     pub async fn clear(&self) {
@@ -48,15 +67,15 @@ mod tests {
     #[tokio::test]
     async fn remove_nonexistent_is_noop() {
         let store = ClientCorrelationStore::new();
-        store.remove("nonexistent").await;
+        assert!(!store.remove("nonexistent").await);
         assert!(!store.contains("nonexistent").await);
     }
 
     #[tokio::test]
     async fn contains_after_clear() {
         let store = ClientCorrelationStore::new();
-        store.register("e1".into()).await;
-        store.register("e2".into()).await;
+        store.register("e1".into(), serde_json::Value::Null).await;
+        store.register("e2".into(), serde_json::Value::Null).await;
         assert!(store.contains("e1").await);
         store.clear().await;
         assert!(!store.contains("e1").await);
@@ -66,9 +85,9 @@ mod tests {
     #[tokio::test]
     async fn register_and_remove_roundtrip() {
         let store = ClientCorrelationStore::new();
-        store.register("e1".into()).await;
+        store.register("e1".into(), serde_json::Value::Null).await;
         assert!(store.contains("e1").await);
-        store.remove("e1").await;
+        assert!(store.remove("e1").await);
         assert!(!store.contains("e1").await);
     }
 }

--- a/src/transport/client/correlation_store.rs
+++ b/src/transport/client/correlation_store.rs
@@ -1,14 +1,27 @@
 //! Client-side correlation store for tracking pending request event IDs.
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use lru::LruCache;
 use tokio::sync::RwLock;
 
+/// A pending request tracked by the correlation store.
+#[derive(Debug, Clone)]
+pub struct PendingRequest {
+    /// The original JSON-RPC request ID before event-ID replacement.
+    pub original_id: serde_json::Value,
+    /// Whether this request is an `initialize` handshake.
+    pub is_initialize: bool,
+}
+
 /// Tracks pending request event IDs and their original request IDs on the client side.
+///
+/// An optional capacity limit enables LRU eviction of the oldest entry when the
+/// store is full.
 #[derive(Clone)]
 pub struct ClientCorrelationStore {
-    pending_requests: Arc<RwLock<HashMap<String, serde_json::Value>>>,
+    pending_requests: Arc<RwLock<LruCache<String, PendingRequest>>>,
 }
 
 impl Default for ClientCorrelationStore {
@@ -20,34 +33,61 @@ impl Default for ClientCorrelationStore {
 impl ClientCorrelationStore {
     pub fn new() -> Self {
         Self {
-            pending_requests: Arc::new(RwLock::new(HashMap::new())),
+            pending_requests: Arc::new(RwLock::new(LruCache::unbounded())),
+        }
+    }
+
+    /// Create a store with an upper bound on pending requests.
+    /// When the limit is reached the oldest entry is evicted.
+    pub fn with_max_pending(max_pending: usize) -> Self {
+        Self {
+            pending_requests: Arc::new(RwLock::new(LruCache::new(
+                NonZeroUsize::new(max_pending).expect("max_pending must be non-zero"),
+            ))),
         }
     }
 
     /// Register a pending request with its original JSON-RPC request ID.
-    pub async fn register(&self, event_id: String, original_id: serde_json::Value) {
+    pub async fn register(
+        &self,
+        event_id: String,
+        original_id: serde_json::Value,
+        is_initialize: bool,
+    ) {
+        self.pending_requests.write().await.push(
+            event_id,
+            PendingRequest {
+                original_id,
+                is_initialize,
+            },
+        );
+    }
+
+    /// Check whether a given event ID corresponds to an `initialize` request.
+    pub async fn is_initialize_request(&self, event_id: &str) -> bool {
         self.pending_requests
-            .write()
+            .read()
             .await
-            .insert(event_id, original_id);
+            .peek(event_id)
+            .is_some_and(|r| r.is_initialize)
     }
 
     pub async fn contains(&self, event_id: &str) -> bool {
-        self.pending_requests.read().await.contains_key(event_id)
+        self.pending_requests.read().await.contains(event_id)
     }
 
     /// Remove a pending request. Returns `true` if the key existed.
     pub async fn remove(&self, event_id: &str) -> bool {
-        self.pending_requests
-            .write()
-            .await
-            .remove(event_id)
-            .is_some()
+        self.pending_requests.write().await.pop(event_id).is_some()
     }
 
     /// Retrieve the original request ID for a given event ID without removing it.
     pub async fn get_original_id(&self, event_id: &str) -> Option<serde_json::Value> {
-        self.pending_requests.read().await.get(event_id).cloned()
+        self.pending_requests
+            .read()
+            .await
+            .peek(event_id)
+            .map(|r| r.original_id.clone())
     }
 
     /// Number of pending requests currently tracked.
@@ -74,8 +114,12 @@ mod tests {
     #[tokio::test]
     async fn contains_after_clear() {
         let store = ClientCorrelationStore::new();
-        store.register("e1".into(), serde_json::Value::Null).await;
-        store.register("e2".into(), serde_json::Value::Null).await;
+        store
+            .register("e1".into(), serde_json::Value::Null, false)
+            .await;
+        store
+            .register("e2".into(), serde_json::Value::Null, false)
+            .await;
         assert!(store.contains("e1").await);
         store.clear().await;
         assert!(!store.contains("e1").await);
@@ -85,7 +129,9 @@ mod tests {
     #[tokio::test]
     async fn register_and_remove_roundtrip() {
         let store = ClientCorrelationStore::new();
-        store.register("e1".into(), serde_json::Value::Null).await;
+        store
+            .register("e1".into(), serde_json::Value::Null, false)
+            .await;
         assert!(store.contains("e1").await);
         assert!(store.remove("e1").await);
         assert!(!store.contains("e1").await);

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -283,8 +283,10 @@ impl NostrClientTransport {
                 error
             })?;
 
-        if matches!(message, JsonRpcMessage::Request(_)) {
-            self.pending_requests.register(event_id.to_hex()).await;
+        if let JsonRpcMessage::Request(ref req) = message {
+            self.pending_requests
+                .register(event_id.to_hex(), req.id.clone())
+                .await;
         }
 
         tracing::debug!(

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -284,8 +284,9 @@ impl NostrClientTransport {
             })?;
 
         if let JsonRpcMessage::Request(ref req) = message {
+            let is_initialize = req.method == INITIALIZE_METHOD;
             self.pending_requests
-                .register(event_id.to_hex(), req.id.clone())
+                .register(event_id.to_hex(), req.id.clone(), is_initialize)
                 .await;
         }
 

--- a/src/transport/server/correlation_store.rs
+++ b/src/transport/server/correlation_store.rs
@@ -1,14 +1,65 @@
-//! Server-side event route store for mapping event IDs to client public keys.
+//! Server-side event route store for mapping event IDs to client routes.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-/// Maps event IDs to client public keys for response routing on the server side.
+/// A route entry for an in-flight request.
+#[derive(Debug, Clone)]
+pub struct RouteEntry {
+    /// The client's public key that originated this request.
+    pub client_pubkey: String,
+    /// The original JSON-RPC request ID (before replacement with event ID).
+    pub original_request_id: serde_json::Value,
+    /// Optional progress token for this request.
+    pub progress_token: Option<String>,
+}
+
+/// Internal state behind the lock.
+struct Inner {
+    /// Primary index: event_id → route entry.
+    routes: HashMap<String, RouteEntry>,
+    /// Secondary index: progress_token → event_id.
+    progress_token_to_event: HashMap<String, String>,
+    /// Secondary index: client_pubkey → set of event_ids.
+    client_event_ids: HashMap<String, HashSet<String>>,
+}
+
+impl Inner {
+    fn new() -> Self {
+        Self {
+            routes: HashMap::new(),
+            progress_token_to_event: HashMap::new(),
+            client_event_ids: HashMap::new(),
+        }
+    }
+
+    /// Remove a single route and clean up all secondary indexes.
+    fn remove_route(&mut self, event_id: &str) -> Option<RouteEntry> {
+        let route = self.routes.remove(event_id)?;
+
+        // Clean up progress token index.
+        if let Some(ref token) = route.progress_token {
+            self.progress_token_to_event.remove(token);
+        }
+
+        // Clean up client index.
+        if let Some(set) = self.client_event_ids.get_mut(&route.client_pubkey) {
+            set.remove(event_id);
+            if set.is_empty() {
+                self.client_event_ids.remove(&route.client_pubkey);
+            }
+        }
+
+        Some(route)
+    }
+}
+
+/// Maps event IDs to full route entries for response routing on the server side.
 #[derive(Clone)]
 pub struct ServerEventRouteStore {
-    event_to_client: Arc<RwLock<HashMap<String, String>>>,
+    inner: Arc<RwLock<Inner>>,
 }
 
 impl Default for ServerEventRouteStore {
@@ -20,43 +71,140 @@ impl Default for ServerEventRouteStore {
 impl ServerEventRouteStore {
     pub fn new() -> Self {
         Self {
-            event_to_client: Arc::new(RwLock::new(HashMap::new())),
+            inner: Arc::new(RwLock::new(Inner::new())),
         }
     }
 
-    pub async fn register(&self, event_id: String, client_pubkey: String) {
-        self.event_to_client
-            .write()
-            .await
-            .insert(event_id, client_pubkey);
+    /// Register a route for an incoming request.
+    pub async fn register(
+        &self,
+        event_id: String,
+        client_pubkey: String,
+        original_request_id: serde_json::Value,
+        progress_token: Option<String>,
+    ) {
+        let mut inner = self.inner.write().await;
+
+        // Update client index.
+        inner
+            .client_event_ids
+            .entry(client_pubkey.clone())
+            .or_default()
+            .insert(event_id.clone());
+
+        // Update progress token index.
+        if let Some(ref token) = progress_token {
+            inner
+                .progress_token_to_event
+                .insert(token.clone(), event_id.clone());
+        }
+
+        inner.routes.insert(
+            event_id,
+            RouteEntry {
+                client_pubkey,
+                original_request_id,
+                progress_token,
+            },
+        );
     }
 
     /// Returns the client public key for the given event ID without removing it.
     pub async fn get(&self, event_id: &str) -> Option<String> {
-        self.event_to_client.read().await.get(event_id).cloned()
-    }
-
-    /// Removes and returns the client public key for the given event ID.
-    pub async fn pop(&self, event_id: &str) -> Option<String> {
-        self.event_to_client.write().await.remove(event_id)
-    }
-
-    /// Removes all routes for a given client public key.
-    pub async fn remove_for_client(&self, client_pubkey: &str) {
-        self.event_to_client
-            .write()
+        self.inner
+            .read()
             .await
-            .retain(|_, v| v != client_pubkey);
+            .routes
+            .get(event_id)
+            .map(|r| r.client_pubkey.clone())
+    }
+
+    /// Returns the full route entry for the given event ID without removing it.
+    pub async fn get_route(&self, event_id: &str) -> Option<RouteEntry> {
+        self.inner.read().await.routes.get(event_id).cloned()
+    }
+
+    /// Removes and returns the full route entry for the given event ID.
+    pub async fn pop(&self, event_id: &str) -> Option<RouteEntry> {
+        self.inner.write().await.remove_route(event_id)
+    }
+
+    /// Removes all routes for a given client public key. Returns the count removed.
+    pub async fn remove_for_client(&self, client_pubkey: &str) -> usize {
+        let mut inner = self.inner.write().await;
+
+        let event_ids = match inner.client_event_ids.remove(client_pubkey) {
+            Some(ids) => ids,
+            None => return 0,
+        };
+
+        let count = event_ids.len();
+        for event_id in &event_ids {
+            if let Some(route) = inner.routes.remove(event_id.as_str()) {
+                if let Some(ref token) = route.progress_token {
+                    inner.progress_token_to_event.remove(token);
+                }
+            }
+        }
+        count
+    }
+
+    /// Check whether a route exists for the given event ID.
+    pub async fn has_event_route(&self, event_id: &str) -> bool {
+        self.inner.read().await.routes.contains_key(event_id)
+    }
+
+    /// Check whether the given client has any active routes.
+    pub async fn has_active_routes_for_client(&self, client_pubkey: &str) -> bool {
+        self.inner
+            .read()
+            .await
+            .client_event_ids
+            .get(client_pubkey)
+            .is_some_and(|set| !set.is_empty())
+    }
+
+    /// Look up the event ID associated with a progress token.
+    pub async fn get_event_id_by_progress_token(&self, token: &str) -> Option<String> {
+        self.inner
+            .read()
+            .await
+            .progress_token_to_event
+            .get(token)
+            .cloned()
+    }
+
+    /// Check whether a progress token mapping exists.
+    pub async fn has_progress_token(&self, token: &str) -> bool {
+        self.inner
+            .read()
+            .await
+            .progress_token_to_event
+            .contains_key(token)
+    }
+
+    /// Number of event routes currently tracked.
+    pub async fn event_route_count(&self) -> usize {
+        self.inner.read().await.routes.len()
+    }
+
+    /// Number of progress token mappings currently tracked.
+    pub async fn progress_token_count(&self) -> usize {
+        self.inner.read().await.progress_token_to_event.len()
     }
 
     pub async fn clear(&self) {
-        self.event_to_client.write().await.clear();
+        let mut inner = self.inner.write().await;
+        inner.routes.clear();
+        inner.progress_token_to_event.clear();
+        inner.client_event_ids.clear();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[tokio::test]
     async fn pop_on_empty_returns_none() {
@@ -67,7 +215,9 @@ mod tests {
     #[tokio::test]
     async fn get_returns_without_removing() {
         let store = ServerEventRouteStore::new();
-        store.register("e1".into(), "pk1".into()).await;
+        store
+            .register("e1".into(), "pk1".into(), json!("r1"), None)
+            .await;
         assert_eq!(store.get("e1").await.as_deref(), Some("pk1"));
         assert_eq!(store.get("e1").await.as_deref(), Some("pk1"));
     }
@@ -75,19 +225,29 @@ mod tests {
     #[tokio::test]
     async fn pop_removes_entry() {
         let store = ServerEventRouteStore::new();
-        store.register("e1".into(), "pk1".into()).await;
-        assert_eq!(store.pop("e1").await.as_deref(), Some("pk1"));
+        store
+            .register("e1".into(), "pk1".into(), json!("r1"), None)
+            .await;
+        let route = store.pop("e1").await.unwrap();
+        assert_eq!(route.client_pubkey, "pk1");
         assert!(store.pop("e1").await.is_none());
     }
 
     #[tokio::test]
     async fn remove_for_client_only_removes_matching() {
         let store = ServerEventRouteStore::new();
-        store.register("e1".into(), "pk1".into()).await;
-        store.register("e2".into(), "pk2".into()).await;
-        store.register("e3".into(), "pk1".into()).await;
+        store
+            .register("e1".into(), "pk1".into(), json!("r1"), None)
+            .await;
+        store
+            .register("e2".into(), "pk2".into(), json!("r2"), None)
+            .await;
+        store
+            .register("e3".into(), "pk1".into(), json!("r3"), None)
+            .await;
 
-        store.remove_for_client("pk1").await;
+        let removed = store.remove_for_client("pk1").await;
+        assert_eq!(removed, 2);
 
         assert!(store.get("e1").await.is_none());
         assert!(store.get("e3").await.is_none());
@@ -97,16 +257,23 @@ mod tests {
     #[tokio::test]
     async fn remove_for_client_noop_when_no_match() {
         let store = ServerEventRouteStore::new();
-        store.register("e1".into(), "pk1".into()).await;
-        store.remove_for_client("pk_other").await;
+        store
+            .register("e1".into(), "pk1".into(), json!("r1"), None)
+            .await;
+        let removed = store.remove_for_client("pk_other").await;
+        assert_eq!(removed, 0);
         assert_eq!(store.get("e1").await.as_deref(), Some("pk1"));
     }
 
     #[tokio::test]
     async fn clear_empties_store() {
         let store = ServerEventRouteStore::new();
-        store.register("e1".into(), "pk1".into()).await;
-        store.register("e2".into(), "pk2".into()).await;
+        store
+            .register("e1".into(), "pk1".into(), json!("r1"), None)
+            .await;
+        store
+            .register("e2".into(), "pk2".into(), json!("r2"), None)
+            .await;
         store.clear().await;
         assert!(store.get("e1").await.is_none());
         assert!(store.get("e2").await.is_none());

--- a/src/transport/server/correlation_store.rs
+++ b/src/transport/server/correlation_store.rs
@@ -1,8 +1,10 @@
 //! Server-side event route store for mapping event IDs to client routes.
 
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use lru::LruCache;
 use tokio::sync::RwLock;
 
 /// A route entry for an in-flight request.
@@ -18,8 +20,8 @@ pub struct RouteEntry {
 
 /// Internal state behind the lock.
 struct Inner {
-    /// Primary index: event_id → route entry.
-    routes: HashMap<String, RouteEntry>,
+    /// Primary index: event_id → route entry (LRU-ordered).
+    routes: LruCache<String, RouteEntry>,
     /// Secondary index: progress_token → event_id.
     progress_token_to_event: HashMap<String, String>,
     /// Secondary index: client_pubkey → set of event_ids.
@@ -27,36 +29,43 @@ struct Inner {
 }
 
 impl Inner {
-    fn new() -> Self {
+    fn new(max_routes: Option<usize>) -> Self {
+        let routes = match max_routes {
+            Some(n) => LruCache::new(NonZeroUsize::new(n).expect("max_routes must be non-zero")),
+            None => LruCache::unbounded(),
+        };
         Self {
-            routes: HashMap::new(),
+            routes,
             progress_token_to_event: HashMap::new(),
             client_event_ids: HashMap::new(),
         }
     }
 
-    /// Remove a single route and clean up all secondary indexes.
-    fn remove_route(&mut self, event_id: &str) -> Option<RouteEntry> {
-        let route = self.routes.remove(event_id)?;
-
-        // Clean up progress token index.
+    /// Clean up secondary indexes for a removed route.
+    fn cleanup_indexes(&mut self, event_id: &str, route: &RouteEntry) {
         if let Some(ref token) = route.progress_token {
             self.progress_token_to_event.remove(token);
         }
-
-        // Clean up client index.
         if let Some(set) = self.client_event_ids.get_mut(&route.client_pubkey) {
             set.remove(event_id);
             if set.is_empty() {
                 self.client_event_ids.remove(&route.client_pubkey);
             }
         }
+    }
 
+    /// Remove a single route and clean up all secondary indexes.
+    fn remove_route(&mut self, event_id: &str) -> Option<RouteEntry> {
+        let route = self.routes.pop(event_id)?;
+        self.cleanup_indexes(event_id, &route);
         Some(route)
     }
 }
 
 /// Maps event IDs to full route entries for response routing on the server side.
+///
+/// An optional capacity limit enables LRU eviction; when the limit is reached
+/// the oldest entry is evicted and its secondary indexes are cleaned up.
 #[derive(Clone)]
 pub struct ServerEventRouteStore {
     inner: Arc<RwLock<Inner>>,
@@ -71,7 +80,15 @@ impl Default for ServerEventRouteStore {
 impl ServerEventRouteStore {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Inner::new())),
+            inner: Arc::new(RwLock::new(Inner::new(None))),
+        }
+    }
+
+    /// Create a store with an upper bound on event routes.
+    /// When the limit is reached the oldest entry is evicted.
+    pub fn with_max_routes(max_routes: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(Inner::new(Some(max_routes)))),
         }
     }
 
@@ -99,14 +116,22 @@ impl ServerEventRouteStore {
                 .insert(token.clone(), event_id.clone());
         }
 
-        inner.routes.insert(
-            event_id,
+        // Insert into LRU; handle possible eviction.
+        let evicted = inner.routes.push(
+            event_id.clone(),
             RouteEntry {
                 client_pubkey,
                 original_request_id,
                 progress_token,
             },
         );
+
+        if let Some((evicted_key, evicted_route)) = evicted {
+            if evicted_key != event_id {
+                // A different entry was evicted due to capacity — clean up its indexes.
+                inner.cleanup_indexes(&evicted_key, &evicted_route);
+            }
+        }
     }
 
     /// Returns the client public key for the given event ID without removing it.
@@ -115,13 +140,13 @@ impl ServerEventRouteStore {
             .read()
             .await
             .routes
-            .get(event_id)
+            .peek(event_id)
             .map(|r| r.client_pubkey.clone())
     }
 
     /// Returns the full route entry for the given event ID without removing it.
     pub async fn get_route(&self, event_id: &str) -> Option<RouteEntry> {
-        self.inner.read().await.routes.get(event_id).cloned()
+        self.inner.read().await.routes.peek(event_id).cloned()
     }
 
     /// Removes and returns the full route entry for the given event ID.
@@ -140,7 +165,7 @@ impl ServerEventRouteStore {
 
         let count = event_ids.len();
         for event_id in &event_ids {
-            if let Some(route) = inner.routes.remove(event_id.as_str()) {
+            if let Some(route) = inner.routes.pop(event_id.as_str()) {
                 if let Some(ref token) = route.progress_token {
                     inner.progress_token_to_event.remove(token);
                 }
@@ -151,7 +176,7 @@ impl ServerEventRouteStore {
 
     /// Check whether a route exists for the given event ID.
     pub async fn has_event_route(&self, event_id: &str) -> bool {
-        self.inner.read().await.routes.contains_key(event_id)
+        self.inner.read().await.routes.contains(event_id)
     }
 
     /// Check whether the given client has any active routes.

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -5,17 +5,17 @@
 //! server announcements.
 
 pub mod correlation_store;
+pub mod session_store;
 
-pub use correlation_store::ServerEventRouteStore;
+pub use correlation_store::{RouteEntry, ServerEventRouteStore};
+pub use session_store::{SessionSnapshot, SessionStore};
 
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
-use tokio::sync::RwLock;
 
 use crate::core::constants::*;
 use crate::core::error::{Error, Result};
@@ -71,9 +71,9 @@ impl Default for NostrServerTransportConfig {
 pub struct NostrServerTransport {
     base: BaseTransport,
     config: NostrServerTransportConfig,
-    /// Client sessions: client_pubkey_hex → ClientSession
-    sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
-    /// Reverse lookup: event_id → client_pubkey_hex
+    /// Client sessions.
+    sessions: SessionStore,
+    /// Reverse lookup: event_id → client route.
     event_routes: ServerEventRouteStore,
     /// Outer gift-wrap event IDs successfully decrypted and verified (inner `verify()`).
     /// Duplicate outer ids are skipped before decrypt; ids are inserted only after success
@@ -133,7 +133,7 @@ impl NostrServerTransport {
                 is_connected: false,
             },
             config,
-            sessions: Arc::new(RwLock::new(HashMap::new())),
+            sessions: SessionStore::new(),
             event_routes: ServerEventRouteStore::new(),
             seen_gift_wrap_ids,
             message_tx: tx,
@@ -167,7 +167,7 @@ impl NostrServerTransport {
                 is_connected: false,
             },
             config,
-            sessions: Arc::new(RwLock::new(HashMap::new())),
+            sessions: SessionStore::new(),
             event_routes: ServerEventRouteStore::new(),
             seen_gift_wrap_ids,
             message_tx: tx,
@@ -279,7 +279,7 @@ impl NostrServerTransport {
     /// Close the transport.
     pub async fn close(&mut self) -> Result<()> {
         self.base.disconnect().await?;
-        self.sessions.write().await.clear();
+        self.sessions.clear().await;
         self.event_routes.clear().await;
         Ok(())
     }
@@ -634,7 +634,7 @@ impl NostrServerTransport {
     #[allow(clippy::too_many_arguments)]
     async fn event_loop(
         relay_pool: Arc<dyn RelayPoolTrait>,
-        sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
+        sessions: SessionStore,
         event_routes: ServerEventRouteStore,
         tx: tokio::sync::mpsc::UnboundedSender<IncomingRequest>,
         allowed_pubkeys: Vec<String>,
@@ -798,28 +798,37 @@ impl NostrServerTransport {
                 // Track request for correlation
                 if let JsonRpcMessage::Request(ref req) = mcp_msg {
                     let original_id = req.id.clone();
-                    session
-                        .pending_requests
-                        .insert(event_id.clone(), original_id);
-                    event_routes
-                        .register(event_id.clone(), sender_pubkey.clone())
-                        .await;
 
-                    // Track progress token
-                    if let Some(token) = req
+                    // Extract progress token from _meta if present.
+                    let progress_token = req
                         .params
                         .as_ref()
                         .and_then(|p| p.get("_meta"))
                         .and_then(|m| m.get("progressToken"))
                         .and_then(|t| t.as_str())
-                    {
+                        .map(String::from);
+
+                    // Duplicate into session fields (kept for backward compat).
+                    session
+                        .pending_requests
+                        .insert(event_id.clone(), original_id.clone());
+                    if let Some(ref token) = progress_token {
                         session
                             .pending_requests
-                            .insert(token.to_string(), serde_json::json!(event_id));
+                            .insert(token.clone(), serde_json::json!(event_id));
                         session
                             .event_to_progress_token
-                            .insert(event_id.clone(), token.to_string());
+                            .insert(event_id.clone(), token.clone());
                     }
+
+                    event_routes
+                        .register(
+                            event_id.clone(),
+                            sender_pubkey.clone(),
+                            original_id,
+                            progress_token,
+                        )
+                        .await;
                 }
 
                 // Handle initialized notification
@@ -843,7 +852,7 @@ impl NostrServerTransport {
     }
 
     async fn cleanup_sessions(
-        sessions: &RwLock<HashMap<String, ClientSession>>,
+        sessions: &SessionStore,
         event_routes: &ServerEventRouteStore,
         timeout: Duration,
     ) -> usize {
@@ -903,7 +912,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_sessions_removes_expired() {
-        let sessions = Arc::new(RwLock::new(HashMap::new()));
+        let sessions = SessionStore::new();
         let event_routes = ServerEventRouteStore::new();
 
         // Insert a session with an old activity time
@@ -916,7 +925,12 @@ mod tests {
             .await
             .insert("pubkey1".to_string(), session);
         event_routes
-            .register("evt1".to_string(), "pubkey1".to_string())
+            .register(
+                "evt1".to_string(),
+                "pubkey1".to_string(),
+                serde_json::json!(1),
+                None,
+            )
             .await;
 
         // With a long timeout, nothing should be cleaned
@@ -927,7 +941,7 @@ mod tests {
         )
         .await;
         assert_eq!(cleaned, 0);
-        assert_eq!(sessions.read().await.len(), 1);
+        assert_eq!(sessions.session_count().await, 1);
 
         // With zero timeout, it should be cleaned
         thread::sleep(Duration::from_millis(5));
@@ -938,17 +952,16 @@ mod tests {
         )
         .await;
         assert_eq!(cleaned, 1);
-        assert!(sessions.read().await.is_empty());
+        assert_eq!(sessions.session_count().await, 0);
         assert!(event_routes.pop("evt1").await.is_none());
     }
 
     #[tokio::test]
     async fn test_cleanup_preserves_active_sessions() {
-        let sessions = Arc::new(RwLock::new(HashMap::new()));
+        let sessions = SessionStore::new();
         let event_routes = ServerEventRouteStore::new();
 
-        let session = ClientSession::new(false);
-        sessions.write().await.insert("active".to_string(), session);
+        sessions.get_or_create_session("active", false).await;
 
         let cleaned = NostrServerTransport::cleanup_sessions(
             &sessions,
@@ -957,7 +970,7 @@ mod tests {
         )
         .await;
         assert_eq!(cleaned, 0);
-        assert_eq!(sessions.read().await.len(), 1);
+        assert_eq!(sessions.session_count().await, 1);
     }
 
     // ── Request ID correlation ──────────────────────────────────

--- a/src/transport/server/session_store.rs
+++ b/src/transport/server/session_store.rs
@@ -1,0 +1,204 @@
+//! Server-side session store for managing client sessions.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::core::types::ClientSession;
+
+/// Manages client sessions keyed by public key (hex).
+#[derive(Clone)]
+pub struct SessionStore {
+    sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
+}
+
+impl Default for SessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionStore {
+    pub fn new() -> Self {
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get an existing session or create a new one. Returns `true` if a new session was created.
+    pub async fn get_or_create_session(&self, client_pubkey: &str, is_encrypted: bool) -> bool {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(client_pubkey) {
+            session.is_encrypted = is_encrypted;
+            false
+        } else {
+            sessions.insert(client_pubkey.to_string(), ClientSession::new(is_encrypted));
+            true
+        }
+    }
+
+    /// Get a read-only snapshot of session fields.
+    /// Returns `None` if the session does not exist.
+    pub async fn get_session(&self, client_pubkey: &str) -> Option<SessionSnapshot> {
+        let sessions = self.sessions.read().await;
+        sessions.get(client_pubkey).map(|s| SessionSnapshot {
+            is_initialized: s.is_initialized,
+            is_encrypted: s.is_encrypted,
+        })
+    }
+
+    /// Mark a session as initialized. Returns `true` if the session existed.
+    pub async fn mark_initialized(&self, client_pubkey: &str) -> bool {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(client_pubkey) {
+            session.is_initialized = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove a session. Returns `true` if it existed.
+    pub async fn remove_session(&self, client_pubkey: &str) -> bool {
+        self.sessions.write().await.remove(client_pubkey).is_some()
+    }
+
+    /// Remove all sessions.
+    pub async fn clear(&self) {
+        self.sessions.write().await.clear();
+    }
+
+    /// Number of active sessions.
+    pub async fn session_count(&self) -> usize {
+        self.sessions.read().await.len()
+    }
+
+    /// Return a snapshot of all sessions as `(client_pubkey, snapshot)` pairs.
+    pub async fn get_all_sessions(&self) -> Vec<(String, SessionSnapshot)> {
+        let sessions = self.sessions.read().await;
+        sessions
+            .iter()
+            .map(|(k, s)| {
+                (
+                    k.clone(),
+                    SessionSnapshot {
+                        is_initialized: s.is_initialized,
+                        is_encrypted: s.is_encrypted,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Acquire write access to the underlying map (transport internals only).
+    pub(crate) async fn write(
+        &self,
+    ) -> tokio::sync::RwLockWriteGuard<'_, HashMap<String, ClientSession>> {
+        self.sessions.write().await
+    }
+
+    /// Acquire read access to the underlying map (transport internals only).
+    pub(crate) async fn read(
+        &self,
+    ) -> tokio::sync::RwLockReadGuard<'_, HashMap<String, ClientSession>> {
+        self.sessions.read().await
+    }
+}
+
+/// A lightweight snapshot of session state (avoids exposing the full `ClientSession`
+/// through the async API boundary).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionSnapshot {
+    pub is_initialized: bool,
+    pub is_encrypted: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_and_retrieve_session() {
+        let store = SessionStore::new();
+
+        let created = store.get_or_create_session("client-1", true).await;
+        assert!(created);
+
+        let snap = store.get_session("client-1").await.unwrap();
+        assert!(snap.is_encrypted);
+        assert!(!snap.is_initialized);
+    }
+
+    #[tokio::test]
+    async fn get_or_create_returns_existing() {
+        let store = SessionStore::new();
+
+        let created = store.get_or_create_session("client-1", false).await;
+        assert!(created);
+
+        let created2 = store.get_or_create_session("client-1", true).await;
+        assert!(!created2);
+
+        // is_encrypted should have been updated.
+        let snap = store.get_session("client-1").await.unwrap();
+        assert!(snap.is_encrypted);
+    }
+
+    #[tokio::test]
+    async fn mark_initialized() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        assert!(store.mark_initialized("client-1").await);
+        let snap = store.get_session("client-1").await.unwrap();
+        assert!(snap.is_initialized);
+    }
+
+    #[tokio::test]
+    async fn mark_initialized_unknown_returns_false() {
+        let store = SessionStore::new();
+        assert!(!store.mark_initialized("unknown").await);
+    }
+
+    #[tokio::test]
+    async fn remove_session() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+        assert!(store.remove_session("client-1").await);
+        assert!(store.get_session("client-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_unknown_returns_false() {
+        let store = SessionStore::new();
+        assert!(!store.remove_session("unknown").await);
+    }
+
+    #[tokio::test]
+    async fn clear_all_sessions() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+        store.get_or_create_session("client-2", true).await;
+
+        store.clear().await;
+
+        assert_eq!(store.session_count().await, 0);
+        assert!(store.get_session("client-1").await.is_none());
+        assert!(store.get_session("client-2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_all_sessions() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+        store.get_or_create_session("client-2", true).await;
+
+        let all = store.get_all_sessions().await;
+        assert_eq!(all.len(), 2);
+
+        let keys: Vec<&str> = all.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&"client-1"));
+        assert!(keys.contains(&"client-2"));
+    }
+}

--- a/tests/conformance_stores.rs
+++ b/tests/conformance_stores.rs
@@ -1,0 +1,725 @@
+//! Conformance tests for store abstractions.
+//!
+//! Ported from the TS SDK:
+//! - `src/transport/nostr-client/correlation-store.test.ts`
+//! - `src/transport/nostr-server/session-store.test.ts`
+//! - `src/transport/nostr-server/correlation-store.test.ts`
+//!
+//! LRU eviction tests are deferred — only non-eviction tests are ported here.
+
+use contextvm_sdk::{ClientCorrelationStore, ServerEventRouteStore, SessionStore};
+use serde_json::json;
+
+// ════════════════════════════════════════════════════════════════════
+// Client Correlation Store
+// ════════════════════════════════════════════════════════════════════
+
+mod client_correlation_store {
+    use super::*;
+
+    // ── registerRequest ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn stores_request_with_event_id() {
+        let store = ClientCorrelationStore::new();
+        store.register("event123".into(), json!("req1")).await;
+        assert!(store.contains("event123").await);
+    }
+
+    #[tokio::test]
+    async fn stores_and_resolves_original_request_id() {
+        let store = ClientCorrelationStore::new();
+        store.register("event456".into(), json!("req2")).await;
+
+        // Retrieve the stored original ID.
+        let original = store.get_original_id("event456").await.unwrap();
+        assert_eq!(original, json!("req2"));
+
+        // After removal the entry is fully gone.
+        assert!(store.remove("event456").await);
+        assert!(store.get_original_id("event456").await.is_none());
+    }
+
+    // ── resolveResponse (get_original_id + remove) ────────────────
+
+    #[tokio::test]
+    async fn restores_original_request_id() {
+        let store = ClientCorrelationStore::new();
+        store.register("event789".into(), json!(42)).await;
+        let original = store.get_original_id("event789").await.unwrap();
+        assert_eq!(original, json!(42));
+    }
+
+    #[tokio::test]
+    async fn returns_none_for_unknown_event_id() {
+        let store = ClientCorrelationStore::new();
+        assert!(store.get_original_id("unknown").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_and_remove_roundtrip() {
+        let store = ClientCorrelationStore::new();
+        store.register("event1".into(), json!("req1")).await;
+
+        // Lookup succeeds before removal.
+        let original = store.get_original_id("event1").await.unwrap();
+        assert_eq!(original, json!("req1"));
+
+        // Remove returns true and cleans up completely.
+        assert!(store.remove("event1").await);
+        assert!(!store.contains("event1").await);
+        assert!(store.get_original_id("event1").await.is_none());
+    }
+
+    // ── removePendingRequest ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn removes_existing_request() {
+        let store = ClientCorrelationStore::new();
+        store.register("event1".into(), json!(null)).await;
+        assert!(store.remove("event1").await);
+        assert!(!store.contains("event1").await);
+    }
+
+    #[tokio::test]
+    async fn returns_false_for_unknown_request() {
+        let store = ClientCorrelationStore::new();
+        assert!(!store.remove("unknown").await);
+    }
+
+    // ── clear ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn removes_all_pending_requests() {
+        let store = ClientCorrelationStore::new();
+        store.register("event1".into(), json!(null)).await;
+        store.register("event2".into(), json!(null)).await;
+        store.clear().await;
+        assert_eq!(store.count().await, 0);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Server Session Store
+// ════════════════════════════════════════════════════════════════════
+
+mod server_session_store {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_and_retrieve_sessions() {
+        let store = SessionStore::new();
+
+        let created = store.get_or_create_session("client-1", true).await;
+        assert!(created);
+
+        let session = store.get_session("client-1").await.unwrap();
+        assert!(session.is_encrypted);
+        assert!(!session.is_initialized);
+
+        // Retrieving same key should return it
+        assert!(store.get_session("client-1").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn mark_sessions_as_initialized() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        let result = store.mark_initialized("client-1").await;
+        assert!(result);
+
+        let session = store.get_session("client-1").await.unwrap();
+        assert!(session.is_initialized);
+    }
+
+    #[tokio::test]
+    async fn remove_sessions() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        let result = store.remove_session("client-1").await;
+        assert!(result);
+        assert!(store.get_session("client-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_all_sessions() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+        store.get_or_create_session("client-2", true).await;
+
+        store.clear().await;
+
+        assert_eq!(store.session_count().await, 0);
+        assert!(store.get_session("client-1").await.is_none());
+        assert!(store.get_session("client-2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn iterate_over_all_sessions() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+        store.get_or_create_session("client-2", true).await;
+
+        let sessions = store.get_all_sessions().await;
+        assert_eq!(sessions.len(), 2);
+
+        let keys: Vec<&str> = sessions.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&"client-1"));
+        assert!(keys.contains(&"client-2"));
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Server Correlation Store (ServerEventRouteStore)
+// ════════════════════════════════════════════════════════════════════
+
+mod server_correlation_store {
+    use super::*;
+
+    // ── registerEventRoute ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn registers_route_with_all_fields() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+
+        let route = store.get_route("event1").await.unwrap();
+        assert_eq!(route.client_pubkey, "client1");
+        assert_eq!(route.original_request_id, json!("req1"));
+        assert_eq!(route.progress_token.as_deref(), Some("token1"));
+    }
+
+    #[tokio::test]
+    async fn registers_route_without_progress_token() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+
+        let route = store.get_route("event1").await.unwrap();
+        assert!(route.progress_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn registers_route_with_numeric_request_id() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!(42), None)
+            .await;
+
+        let route = store.get_route("event1").await.unwrap();
+        assert_eq!(route.original_request_id, json!(42));
+    }
+
+    #[tokio::test]
+    async fn updates_client_index_when_registering() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client1".into(), json!("req2"), None)
+            .await;
+
+        assert!(store.has_active_routes_for_client("client1").await);
+    }
+
+    #[tokio::test]
+    async fn registers_progress_token_mapping() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+
+        assert_eq!(
+            store
+                .get_event_id_by_progress_token("token1")
+                .await
+                .as_deref(),
+            Some("event1")
+        );
+        assert!(store.has_progress_token("token1").await);
+    }
+
+    // ── getEventRoute ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn returns_none_for_unknown_event_id() {
+        let store = ServerEventRouteStore::new();
+        assert!(store.get_route("unknown").await.is_none());
+    }
+
+    // ── popEventRoute ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn returns_and_removes_route_atomically() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+
+        let route = store.pop("event1").await.unwrap();
+        assert_eq!(route.client_pubkey, "client1");
+        assert_eq!(route.original_request_id, json!("req1"));
+        assert_eq!(route.progress_token.as_deref(), Some("token1"));
+
+        // Route + token mapping should be gone.
+        assert!(!store.has_event_route("event1").await);
+        assert!(!store.has_progress_token("token1").await);
+
+        // Second pop is a no-op.
+        assert!(store.pop("event1").await.is_none());
+    }
+
+    // ── getEventIdByProgressToken ─────────────────────────────────
+
+    #[tokio::test]
+    async fn returns_none_for_unknown_token() {
+        let store = ServerEventRouteStore::new();
+        assert!(store
+            .get_event_id_by_progress_token("unknown")
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn returns_correct_event_id_for_token() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        store
+            .register(
+                "event2".into(),
+                "client2".into(),
+                json!("req2"),
+                Some("token2".into()),
+            )
+            .await;
+
+        assert_eq!(
+            store
+                .get_event_id_by_progress_token("token1")
+                .await
+                .as_deref(),
+            Some("event1")
+        );
+        assert_eq!(
+            store
+                .get_event_id_by_progress_token("token2")
+                .await
+                .as_deref(),
+            Some("event2")
+        );
+    }
+
+    // ── removeRoutesForClient ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn removes_all_routes_for_client() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client1".into(), json!("req2"), None)
+            .await;
+        store
+            .register("event3".into(), "client2".into(), json!("req3"), None)
+            .await;
+
+        let removed = store.remove_for_client("client1").await;
+        assert_eq!(removed, 2);
+
+        assert!(!store.has_event_route("event1").await);
+        assert!(!store.has_event_route("event2").await);
+        assert!(store.has_event_route("event3").await);
+    }
+
+    #[tokio::test]
+    async fn returns_zero_for_unknown_client() {
+        let store = ServerEventRouteStore::new();
+        assert_eq!(store.remove_for_client("unknown").await, 0);
+    }
+
+    #[tokio::test]
+    async fn cleans_up_progress_tokens_for_removed_routes() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        store
+            .register(
+                "event2".into(),
+                "client1".into(),
+                json!("req2"),
+                Some("token2".into()),
+            )
+            .await;
+
+        store.remove_for_client("client1").await;
+
+        assert!(!store.has_progress_token("token1").await);
+        assert!(!store.has_progress_token("token2").await);
+    }
+
+    #[tokio::test]
+    async fn removes_client_from_index_after_cleanup() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+
+        store.remove_for_client("client1").await;
+
+        assert!(!store.has_active_routes_for_client("client1").await);
+    }
+
+    // ── hasEventRoute ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn has_event_route_true_for_existing() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        assert!(store.has_event_route("event1").await);
+    }
+
+    #[tokio::test]
+    async fn has_event_route_false_for_unknown() {
+        let store = ServerEventRouteStore::new();
+        assert!(!store.has_event_route("unknown").await);
+    }
+
+    // ── hasProgressToken ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn has_progress_token_true_for_existing() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        assert!(store.has_progress_token("token1").await);
+    }
+
+    #[tokio::test]
+    async fn has_progress_token_false_for_unknown() {
+        let store = ServerEventRouteStore::new();
+        assert!(!store.has_progress_token("unknown").await);
+    }
+
+    // ── hasActiveRoutesForClient ──────────────────────────────────
+
+    #[tokio::test]
+    async fn has_active_routes_true_when_routes_exist() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        assert!(store.has_active_routes_for_client("client1").await);
+    }
+
+    #[tokio::test]
+    async fn has_active_routes_false_when_no_routes() {
+        let store = ServerEventRouteStore::new();
+        assert!(!store.has_active_routes_for_client("client1").await);
+    }
+
+    #[tokio::test]
+    async fn has_active_routes_false_after_all_popped() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store.pop("event1").await;
+        assert!(!store.has_active_routes_for_client("client1").await);
+    }
+
+    // ── eventRouteCount ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn event_route_count_zero_for_empty() {
+        let store = ServerEventRouteStore::new();
+        assert_eq!(store.event_route_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn event_route_count_after_registrations() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client1".into(), json!("req2"), None)
+            .await;
+        assert_eq!(store.event_route_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn event_route_count_after_removals() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client1".into(), json!("req2"), None)
+            .await;
+        store.pop("event1").await;
+        assert_eq!(store.event_route_count().await, 1);
+    }
+
+    // ── progressTokenCount ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn progress_token_count_zero_for_empty() {
+        let store = ServerEventRouteStore::new();
+        assert_eq!(store.progress_token_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn progress_token_count_after_registrations() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        store
+            .register(
+                "event2".into(),
+                "client1".into(),
+                json!("req2"),
+                Some("token2".into()),
+            )
+            .await;
+        store
+            .register("event3".into(), "client1".into(), json!("req3"), None)
+            .await;
+        assert_eq!(store.progress_token_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn progress_token_count_after_removals() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        store
+            .register(
+                "event2".into(),
+                "client1".into(),
+                json!("req2"),
+                Some("token2".into()),
+            )
+            .await;
+        store.pop("event1").await;
+        assert_eq!(store.progress_token_count().await, 1);
+    }
+
+    // ── clear ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn clear_removes_all_routes() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client2".into(), json!("req2"), None)
+            .await;
+
+        store.clear().await;
+
+        assert_eq!(store.event_route_count().await, 0);
+        assert!(!store.has_event_route("event1").await);
+    }
+
+    #[tokio::test]
+    async fn clear_removes_all_progress_tokens() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+
+        store.clear().await;
+
+        assert_eq!(store.progress_token_count().await, 0);
+        assert!(!store.has_progress_token("token1").await);
+    }
+
+    #[tokio::test]
+    async fn clear_cleans_up_client_index() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+
+        store.clear().await;
+
+        assert!(!store.has_active_routes_for_client("client1").await);
+    }
+
+    // ── complex scenarios ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn handles_multiple_clients_with_multiple_routes() {
+        let store = ServerEventRouteStore::new();
+
+        // Client 1: 2 routes
+        store
+            .register(
+                "c1e1".into(),
+                "client1".into(),
+                json!("r1"),
+                Some("t1".into()),
+            )
+            .await;
+        store
+            .register(
+                "c1e2".into(),
+                "client1".into(),
+                json!("r2"),
+                Some("t2".into()),
+            )
+            .await;
+
+        // Client 2: 1 route
+        store
+            .register(
+                "c2e1".into(),
+                "client2".into(),
+                json!("r3"),
+                Some("t3".into()),
+            )
+            .await;
+
+        assert_eq!(store.event_route_count().await, 3);
+        assert_eq!(store.progress_token_count().await, 3);
+        assert!(store.has_active_routes_for_client("client1").await);
+        assert!(store.has_active_routes_for_client("client2").await);
+
+        // Remove one of client1's routes
+        store.pop("c1e1").await;
+
+        assert!(store.has_active_routes_for_client("client1").await);
+        assert!(!store.has_progress_token("t1").await);
+        assert!(store.has_progress_token("t2").await);
+    }
+
+    #[tokio::test]
+    async fn handles_route_replacement_with_same_progress_token() {
+        let store = ServerEventRouteStore::new();
+
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        assert_eq!(
+            store
+                .get_event_id_by_progress_token("token1")
+                .await
+                .as_deref(),
+            Some("event1")
+        );
+
+        // Register new route with same token (overwrites mapping)
+        store
+            .register(
+                "event2".into(),
+                "client1".into(),
+                json!("req2"),
+                Some("token1".into()),
+            )
+            .await;
+        assert_eq!(
+            store
+                .get_event_id_by_progress_token("token1")
+                .await
+                .as_deref(),
+            Some("event2")
+        );
+    }
+
+    #[tokio::test]
+    async fn maintains_consistency_through_mixed_operations() {
+        let store = ServerEventRouteStore::new();
+
+        // Add routes
+        store
+            .register("e1".into(), "c1".into(), json!("r1"), Some("t1".into()))
+            .await;
+        store
+            .register("e2".into(), "c1".into(), json!("r2"), Some("t2".into()))
+            .await;
+        store
+            .register("e3".into(), "c2".into(), json!("r3"), Some("t3".into()))
+            .await;
+
+        // Remove one
+        store.pop("e2").await;
+
+        // Verify consistency
+        assert!(store.has_event_route("e1").await);
+        assert!(!store.has_event_route("e2").await);
+        assert!(store.has_event_route("e3").await);
+
+        assert!(store.has_progress_token("t1").await);
+        assert!(!store.has_progress_token("t2").await);
+        assert!(store.has_progress_token("t3").await);
+
+        assert!(store.has_active_routes_for_client("c1").await);
+        assert!(store.has_active_routes_for_client("c2").await);
+    }
+}

--- a/tests/conformance_stores.rs
+++ b/tests/conformance_stores.rs
@@ -4,8 +4,6 @@
 //! - `src/transport/nostr-client/correlation-store.test.ts`
 //! - `src/transport/nostr-server/session-store.test.ts`
 //! - `src/transport/nostr-server/correlation-store.test.ts`
-//!
-//! LRU eviction tests are deferred — only non-eviction tests are ported here.
 
 use contextvm_sdk::{ClientCorrelationStore, ServerEventRouteStore, SessionStore};
 use serde_json::json;
@@ -22,14 +20,18 @@ mod client_correlation_store {
     #[tokio::test]
     async fn stores_request_with_event_id() {
         let store = ClientCorrelationStore::new();
-        store.register("event123".into(), json!("req1")).await;
+        store
+            .register("event123".into(), json!("req1"), false)
+            .await;
         assert!(store.contains("event123").await);
     }
 
     #[tokio::test]
     async fn stores_and_resolves_original_request_id() {
         let store = ClientCorrelationStore::new();
-        store.register("event456".into(), json!("req2")).await;
+        store
+            .register("event456".into(), json!("req2"), false)
+            .await;
 
         // Retrieve the stored original ID.
         let original = store.get_original_id("event456").await.unwrap();
@@ -40,12 +42,23 @@ mod client_correlation_store {
         assert!(store.get_original_id("event456").await.is_none());
     }
 
+    #[tokio::test]
+    async fn register_request_flags_initialize_requests() {
+        let store = ClientCorrelationStore::new();
+        store.register("e_init".into(), json!("r1"), true).await;
+        store.register("e_normal".into(), json!("r2"), false).await;
+
+        assert!(store.is_initialize_request("e_init").await);
+        assert!(!store.is_initialize_request("e_normal").await);
+        assert!(!store.is_initialize_request("unknown").await);
+    }
+
     // ── resolveResponse (get_original_id + remove) ────────────────
 
     #[tokio::test]
     async fn restores_original_request_id() {
         let store = ClientCorrelationStore::new();
-        store.register("event789".into(), json!(42)).await;
+        store.register("event789".into(), json!(42), false).await;
         let original = store.get_original_id("event789").await.unwrap();
         assert_eq!(original, json!(42));
     }
@@ -59,7 +72,7 @@ mod client_correlation_store {
     #[tokio::test]
     async fn get_and_remove_roundtrip() {
         let store = ClientCorrelationStore::new();
-        store.register("event1".into(), json!("req1")).await;
+        store.register("event1".into(), json!("req1"), false).await;
 
         // Lookup succeeds before removal.
         let original = store.get_original_id("event1").await.unwrap();
@@ -76,7 +89,7 @@ mod client_correlation_store {
     #[tokio::test]
     async fn removes_existing_request() {
         let store = ClientCorrelationStore::new();
-        store.register("event1".into(), json!(null)).await;
+        store.register("event1".into(), json!(null), false).await;
         assert!(store.remove("event1").await);
         assert!(!store.contains("event1").await);
     }
@@ -92,10 +105,29 @@ mod client_correlation_store {
     #[tokio::test]
     async fn removes_all_pending_requests() {
         let store = ClientCorrelationStore::new();
-        store.register("event1".into(), json!(null)).await;
-        store.register("event2".into(), json!(null)).await;
+        store.register("event1".into(), json!(null), false).await;
+        store.register("event2".into(), json!(null), false).await;
         store.clear().await;
         assert_eq!(store.count().await, 0);
+    }
+
+    // ── LRU eviction (TS SDK client test 9) ───────────────────────
+
+    #[tokio::test]
+    async fn evicts_oldest_when_capacity_reached() {
+        let store = ClientCorrelationStore::with_max_pending(2);
+        for i in 0..5 {
+            store
+                .register(format!("event{i}"), json!(null), false)
+                .await;
+        }
+        assert_eq!(store.count().await, 2);
+        // Only the two most recent entries survive.
+        assert!(!store.contains("event0").await);
+        assert!(!store.contains("event1").await);
+        assert!(!store.contains("event2").await);
+        assert!(store.contains("event3").await);
+        assert!(store.contains("event4").await);
     }
 }
 
@@ -721,5 +753,67 @@ mod server_correlation_store {
 
         assert!(store.has_active_routes_for_client("c1").await);
         assert!(store.has_active_routes_for_client("c2").await);
+    }
+
+    // ── LRU eviction (TS SDK server tests 28–30) ─────────────────
+
+    #[tokio::test]
+    async fn evicts_oldest_route_when_capacity_reached() {
+        let store = ServerEventRouteStore::with_max_routes(2);
+
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client1".into(), json!("req2"), None)
+            .await;
+        store
+            .register("event3".into(), "client1".into(), json!("req3"), None)
+            .await;
+
+        // event1 should have been evicted.
+        assert!(!store.has_event_route("event1").await);
+        assert_eq!(store.event_route_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn cleans_up_progress_tokens_on_eviction() {
+        let store = ServerEventRouteStore::with_max_routes(1);
+
+        store
+            .register(
+                "event1".into(),
+                "client1".into(),
+                json!("req1"),
+                Some("token1".into()),
+            )
+            .await;
+        store
+            .register(
+                "event2".into(),
+                "client1".into(),
+                json!("req2"),
+                Some("token2".into()),
+            )
+            .await;
+
+        assert!(!store.has_progress_token("token1").await);
+        assert!(store.has_progress_token("token2").await);
+    }
+
+    #[tokio::test]
+    async fn cleans_up_client_index_on_eviction() {
+        let store = ServerEventRouteStore::with_max_routes(1);
+
+        store
+            .register("event1".into(), "client1".into(), json!("req1"), None)
+            .await;
+        store
+            .register("event2".into(), "client2".into(), json!("req2"), None)
+            .await;
+
+        // client1's only route was evicted.
+        assert!(!store.has_active_routes_for_client("client1").await);
+        assert!(store.has_active_routes_for_client("client2").await);
     }
 }


### PR DESCRIPTION
The existing stores were too thin to port most of the Phase 1 and Phase 2 conformance tests, ClientCorrelationStore was a bare HashSet and ServerEventRouteStore only mapped event_id to client_pubkey.

Changes:

ClientCorrelationStore now tracks originalRequestId per event, remove returns bool and a count accessor is added.

ServerEventRouteStore now stores full route objects (originalRequestId + progressToken), adds a progress token index, client activity index, and accessors for hasEventRoute, hasActiveRoutesForClient, eventRouteCount, progressTokenCount.

SessionStore is a new dedicated struct replacing the inline Arc<RwLock<HashMap>> in NostrServerTransport, with getOrCreateSession, getSession, markInitialized, removeSession, clear, sessionCount and getAllSessions.

All existing call sites updated. No existing behavior changed.

45 new conformance tests in tests/conformance_stores.rs porting the TS SDK client correlation, server session, and server correlation store test suites. LRU eviction tests deferred to a follow-up PR.

219 tests passing.

Closes #40, #14 and #28 
