### PR TITLE
CEP1-19 Part2: Client side integration

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -110,6 +110,7 @@ mod tests {
             relay_urls: vec!["wss://relay.example.com".to_string()],
             server_pubkey: server_pubkey.clone(),
             encryption_mode: EncryptionMode::Required,
+            gift_wrap_mode: GiftWrapMode::Optional,
             is_stateless: true,
             timeout: Duration::from_secs(60),
             log_file_path: None,

--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -112,6 +112,7 @@ impl BaseTransport {
         kind: u16,
         tags: Vec<Tag>,
         is_encrypted: Option<bool>,
+        gift_wrap_kind: Option<u16>,
     ) -> Result<EventId> {
         let should_encrypt = self.should_encrypt(kind, is_encrypted);
 
@@ -128,13 +129,20 @@ impl BaseTransport {
                 .signer()
                 .await
                 .map_err(|e| Error::Encryption(e.to_string()))?;
-            let gift_wrap_event =
-                encryption::gift_wrap_single_layer(&signer, recipient, &event_json).await?;
+            let selected_gift_wrap_kind = gift_wrap_kind.unwrap_or(GIFT_WRAP_KIND);
+            let gift_wrap_event = encryption::gift_wrap_single_layer_with_kind(
+                &signer,
+                recipient,
+                &event_json,
+                selected_gift_wrap_kind,
+            )
+            .await?;
             self.relay_pool.publish_event(&gift_wrap_event).await?;
             tracing::debug!(
                 target: LOG_TARGET,
                 signed_event_id = %signed_event_id,
                 envelope_id = %gift_wrap_event.id,
+                gift_wrap_kind = selected_gift_wrap_kind,
                 "Sent encrypted MCP message"
             );
         } else {

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -8,6 +8,7 @@ pub mod correlation_store;
 pub use correlation_store::ClientCorrelationStore;
 
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -35,6 +36,8 @@ pub struct NostrClientTransportConfig {
     pub server_pubkey: String,
     /// Encryption mode.
     pub encryption_mode: EncryptionMode,
+    /// Gift-wrap policy for encrypted messages.
+    pub gift_wrap_mode: GiftWrapMode,
     /// Stateless mode: emulate initialize response locally.
     pub is_stateless: bool,
     /// Response timeout (default: 30s).
@@ -49,6 +52,7 @@ impl Default for NostrClientTransportConfig {
             relay_urls: vec!["wss://relay.damus.io".to_string()],
             server_pubkey: String::new(),
             encryption_mode: EncryptionMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Optional,
             is_stateless: false,
             timeout: Duration::from_secs(30),
             log_file_path: None,
@@ -63,6 +67,8 @@ pub struct NostrClientTransport {
     server_pubkey: PublicKey,
     /// Pending request event IDs awaiting responses.
     pending_requests: ClientCorrelationStore,
+    /// Learned support for server-side ephemeral gift wraps.
+    server_supports_ephemeral: Arc<AtomicBool>,
     /// Outer gift-wrap event IDs successfully decrypted and verified (inner `verify()`).
     /// Duplicate outer ids are skipped before decrypt; ids are inserted only after success
     /// so failed decrypt/verify can be retried on redelivery.
@@ -120,6 +126,7 @@ impl NostrClientTransport {
             config,
             server_pubkey,
             pending_requests: ClientCorrelationStore::new(),
+            server_supports_ephemeral: Arc::new(AtomicBool::new(false)),
             seen_gift_wrap_ids,
             message_tx: tx,
             message_rx: Some(rx),
@@ -164,6 +171,7 @@ impl NostrClientTransport {
             config,
             server_pubkey,
             pending_requests: ClientCorrelationStore::new(),
+            server_supports_ephemeral: Arc::new(AtomicBool::new(false)),
             seen_gift_wrap_ids,
             message_tx: tx,
             message_rx: Some(rx),
@@ -217,6 +225,8 @@ impl NostrClientTransport {
         let server_pubkey = self.server_pubkey;
         let tx = self.message_tx.clone();
         let encryption_mode = self.config.encryption_mode;
+        let gift_wrap_mode = self.config.gift_wrap_mode;
+        let server_supports_ephemeral = self.server_supports_ephemeral.clone();
         let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
 
         tokio::spawn(async move {
@@ -226,6 +236,8 @@ impl NostrClientTransport {
                 server_pubkey,
                 tx,
                 encryption_mode,
+                gift_wrap_mode,
+                server_supports_ephemeral,
                 seen_gift_wrap_ids,
             )
             .await;
@@ -270,6 +282,7 @@ impl NostrClientTransport {
                 CTXVM_MESSAGES_KIND,
                 tags,
                 None,
+                Some(self.choose_outbound_gift_wrap_kind()),
             )
             .await
             .map_err(|error| {
@@ -323,12 +336,15 @@ impl NostrClientTransport {
         let _ = self.message_tx.send(response);
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn event_loop(
         relay_pool: Arc<dyn RelayPoolTrait>,
         pending: ClientCorrelationStore,
         server_pubkey: PublicKey,
         tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
         encryption_mode: EncryptionMode,
+        gift_wrap_mode: GiftWrapMode,
+        server_supports_ephemeral: Arc<AtomicBool>,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     ) {
         let mut notifications = relay_pool.notifications();
@@ -336,25 +352,42 @@ impl NostrClientTransport {
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event { event, .. } = notification {
                 let is_gift_wrap = is_gift_wrap_kind(&event.kind);
+                let outer_kind = event.kind.as_u16();
 
-                // Enforce mode before decrypt/parse.
+                // Enforce encryption mode before decrypt/parse.
                 if violates_encryption_policy(&event.kind, &encryption_mode) {
                     if is_gift_wrap {
                         tracing::warn!(
+                            target: LOG_TARGET,
                             event_id = %event.id.to_hex(),
-                            "Received encrypted response but encryption is disabled"
+                            event_kind = outer_kind,
+                            configured_mode = ?gift_wrap_mode,
+                            "Skipping encrypted response because client encryption is disabled"
                         );
                     } else {
                         tracing::warn!(
+                            target: LOG_TARGET,
                             event_id = %event.id.to_hex(),
-                            "Received unencrypted response but encryption is required"
+                            "Skipping plaintext response because client encryption is required"
                         );
                     }
                     continue;
                 }
 
+                // Enforce CEP-19 gift-wrap-mode policy.
+                if is_gift_wrap && !gift_wrap_mode.allows_kind(outer_kind) {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        event_id = %event.id.to_hex(),
+                        event_kind = outer_kind,
+                        configured_mode = ?gift_wrap_mode,
+                        "Skipping gift wrap due to CEP-19 policy"
+                    );
+                    continue;
+                }
+
                 // Handle gift-wrapped events
-                let (actual_event_content, actual_pubkey, e_tag) = if is_gift_wrap {
+                let (actual_event_content, actual_pubkey, e_tag, verified_tags) = if is_gift_wrap {
                     {
                         let guard = match seen_gift_wrap_ids.lock() {
                             Ok(g) => g,
@@ -399,7 +432,7 @@ impl NostrClientTransport {
                                         guard.put(event.id, ());
                                     }
                                     let e_tag = serializers::get_tag_value(&inner.tags, "e");
-                                    (inner.content, inner.pubkey, e_tag)
+                                    (inner.content, inner.pubkey, e_tag, inner.tags)
                                 }
                                 Err(error) => {
                                     tracing::error!(
@@ -422,7 +455,12 @@ impl NostrClientTransport {
                     }
                 } else {
                     let e_tag = serializers::get_tag_value(&event.tags, "e");
-                    (event.content.clone(), event.pubkey, e_tag)
+                    (
+                        event.content.clone(),
+                        event.pubkey,
+                        e_tag,
+                        event.tags.clone(),
+                    )
                 };
 
                 // Verify it's from our server
@@ -434,6 +472,16 @@ impl NostrClientTransport {
                         "Skipping event from unexpected pubkey"
                     );
                     continue;
+                }
+
+                // CEP-19: learn ephemeral support from server
+                if Self::should_learn_ephemeral_support(
+                    actual_pubkey,
+                    server_pubkey,
+                    if is_gift_wrap { Some(outer_kind) } else { None },
+                    &verified_tags,
+                ) {
+                    server_supports_ephemeral.store(true, Ordering::Relaxed);
                 }
 
                 // Correlate response
@@ -459,6 +507,45 @@ impl NostrClientTransport {
                 }
             }
         }
+    }
+
+    fn choose_outbound_gift_wrap_kind(&self) -> u16 {
+        match self.config.gift_wrap_mode {
+            GiftWrapMode::Persistent => GIFT_WRAP_KIND,
+            GiftWrapMode::Ephemeral => EPHEMERAL_GIFT_WRAP_KIND,
+            GiftWrapMode::Optional => {
+                if self.server_supports_ephemeral.load(Ordering::Relaxed) {
+                    EPHEMERAL_GIFT_WRAP_KIND
+                } else {
+                    GIFT_WRAP_KIND
+                }
+            }
+        }
+    }
+
+    fn has_support_ephemeral_tag(tags: &Tags) -> bool {
+        tags.iter().any(|tag| {
+            tag.kind()
+                == TagKind::Custom(
+                    crate::core::constants::tags::SUPPORT_ENCRYPTION_EPHEMERAL.into(),
+                )
+        })
+    }
+
+    fn should_learn_ephemeral_support(
+        actual_pubkey: PublicKey,
+        server_pubkey: PublicKey,
+        event_kind: Option<u16>,
+        tags: &Tags,
+    ) -> bool {
+        actual_pubkey == server_pubkey
+            && (event_kind == Some(EPHEMERAL_GIFT_WRAP_KIND)
+                || Self::has_support_ephemeral_tag(tags))
+    }
+
+    /// Returns whether the client has learned ephemeral gift-wrap support from the server.
+    pub fn server_supports_ephemeral_encryption(&self) -> bool {
+        self.server_supports_ephemeral.load(Ordering::Relaxed)
     }
 }
 
@@ -486,6 +573,7 @@ mod tests {
         assert_eq!(config.relay_urls, vec!["wss://relay.damus.io".to_string()]);
         assert!(config.server_pubkey.is_empty());
         assert_eq!(config.encryption_mode, EncryptionMode::Optional);
+        assert_eq!(config.gift_wrap_mode, GiftWrapMode::Optional);
         assert!(!config.is_stateless);
         assert_eq!(config.timeout, Duration::from_secs(30));
         assert!(config.log_file_path.is_none());
@@ -501,8 +589,77 @@ mod tests {
     }
 
     #[test]
+    fn test_has_support_ephemeral_tag_detects_capability() {
+        let tags = Tags::from_list(vec![Tag::custom(
+            TagKind::Custom(crate::core::constants::tags::SUPPORT_ENCRYPTION_EPHEMERAL.into()),
+            Vec::<String>::new(),
+        )]);
+        assert!(NostrClientTransport::has_support_ephemeral_tag(&tags));
+    }
+
+    #[test]
+    fn test_has_support_ephemeral_tag_absent() {
+        let tags = Tags::from_list(vec![Tag::custom(
+            TagKind::Custom(crate::core::constants::tags::SUPPORT_ENCRYPTION.into()),
+            Vec::<String>::new(),
+        )]);
+        assert!(!NostrClientTransport::has_support_ephemeral_tag(&tags));
+    }
+
+    #[test]
+    fn test_should_learn_ephemeral_support_requires_matching_server_pubkey() {
+        let server_keys = Keys::generate();
+        let other_keys = Keys::generate();
+        let tags = Tags::from_list(vec![Tag::custom(
+            TagKind::Custom(crate::core::constants::tags::SUPPORT_ENCRYPTION_EPHEMERAL.into()),
+            Vec::<String>::new(),
+        )]);
+
+        assert!(!NostrClientTransport::should_learn_ephemeral_support(
+            other_keys.public_key(),
+            server_keys.public_key(),
+            Some(EPHEMERAL_GIFT_WRAP_KIND),
+            &tags,
+        ));
+        assert!(NostrClientTransport::should_learn_ephemeral_support(
+            server_keys.public_key(),
+            server_keys.public_key(),
+            Some(EPHEMERAL_GIFT_WRAP_KIND),
+            &tags,
+        ));
+    }
+
+    #[test]
+    fn test_should_learn_from_ephemeral_kind_even_without_tag() {
+        let server_keys = Keys::generate();
+        let empty_tags = Tags::from_list(vec![]);
+
+        assert!(NostrClientTransport::should_learn_ephemeral_support(
+            server_keys.public_key(),
+            server_keys.public_key(),
+            Some(EPHEMERAL_GIFT_WRAP_KIND),
+            &empty_tags,
+        ));
+    }
+
+    #[test]
+    fn test_should_learn_from_tag_without_ephemeral_kind() {
+        let server_keys = Keys::generate();
+        let tags = Tags::from_list(vec![Tag::custom(
+            TagKind::Custom(crate::core::constants::tags::SUPPORT_ENCRYPTION_EPHEMERAL.into()),
+            Vec::<String>::new(),
+        )]);
+
+        assert!(NostrClientTransport::should_learn_ephemeral_support(
+            server_keys.public_key(),
+            server_keys.public_key(),
+            Some(GIFT_WRAP_KIND), // persistent kind, but tag present
+            &tags,
+        ));
+    }
+
+    #[test]
     fn test_stateless_emulated_initialize_response_shape() {
-        // Verify the emulated response has the expected structure
         let request_id = serde_json::json!(1);
         let response = JsonRpcMessage::Response(JsonRpcResponse {
             jsonrpc: "2.0".to_string(),

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -346,6 +346,7 @@ impl NostrServerTransport {
                 CTXVM_MESSAGES_KIND,
                 tags,
                 Some(is_encrypted),
+                None,
             )
             .await
             .map_err(|error| {
@@ -412,6 +413,7 @@ impl NostrServerTransport {
                 CTXVM_MESSAGES_KIND,
                 tags,
                 Some(is_encrypted),
+                None,
             )
             .await?;
 

--- a/tests/conformance_stateless_mode.rs
+++ b/tests/conformance_stateless_mode.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use contextvm_sdk::core::constants::{mcp_protocol_version, INITIALIZE_METHOD};
-use contextvm_sdk::core::types::{EncryptionMode, JsonRpcMessage, JsonRpcRequest};
+use contextvm_sdk::core::types::{EncryptionMode, GiftWrapMode, JsonRpcMessage, JsonRpcRequest};
 use contextvm_sdk::signer;
 use contextvm_sdk::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use tokio::time::timeout;
@@ -19,6 +19,7 @@ async fn make_stateless_transport() -> (
         relay_urls: Vec::new(),
         server_pubkey: server_keys.public_key().to_hex(),
         encryption_mode: EncryptionMode::Optional,
+        gift_wrap_mode: GiftWrapMode::Optional,
         is_stateless: true,
         timeout: Duration::from_secs(1),
         log_file_path: None,


### PR DESCRIPTION
This PR integrates the CEP-19 ephemeral package handling at the client side. The main behaviour is picked from Ts sdk and implements the following features, apart from package handling
1) learning ephemeral support for the server
2) outbound kind selection
3) inbound gift-wrap policy check
4) dedup against envelope id
