### PR TITLE
bug(transport): non atomic send_response behaviour

### DIFF
--- a/src/transport/client/correlation_store.rs
+++ b/src/transport/client/correlation_store.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use lru::LruCache;
 use tokio::sync::RwLock;
 
+use crate::core::constants::DEFAULT_LRU_SIZE;
+
 /// A pending request tracked by the correlation store.
 #[derive(Debug, Clone)]
 pub struct PendingRequest {
@@ -32,9 +34,7 @@ impl Default for ClientCorrelationStore {
 
 impl ClientCorrelationStore {
     pub fn new() -> Self {
-        Self {
-            pending_requests: Arc::new(RwLock::new(LruCache::unbounded())),
-        }
+        Self::with_max_pending(DEFAULT_LRU_SIZE)
     }
 
     /// Create a store with an upper bound on pending requests.
@@ -135,5 +135,19 @@ mod tests {
         assert!(store.contains("e1").await);
         assert!(store.remove("e1").await);
         assert!(!store.contains("e1").await);
+    }
+
+    #[tokio::test]
+    async fn default_store_is_bounded() {
+        let store = ClientCorrelationStore::new();
+        for i in 0..=DEFAULT_LRU_SIZE {
+            store
+                .register(format!("e{i}"), serde_json::Value::Null, false)
+                .await;
+        }
+
+        assert_eq!(store.count().await, DEFAULT_LRU_SIZE);
+        assert!(!store.contains("e0").await);
+        assert!(store.contains(&format!("e{DEFAULT_LRU_SIZE}")).await);
     }
 }

--- a/src/transport/server/correlation_store.rs
+++ b/src/transport/server/correlation_store.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use lru::LruCache;
 use tokio::sync::RwLock;
 
+use crate::core::constants::DEFAULT_LRU_SIZE;
+
 /// A route entry for an in-flight request.
 #[derive(Debug, Clone)]
 pub struct RouteEntry {
@@ -29,11 +31,9 @@ struct Inner {
 }
 
 impl Inner {
-    fn new(max_routes: Option<usize>) -> Self {
-        let routes = match max_routes {
-            Some(n) => LruCache::new(NonZeroUsize::new(n).expect("max_routes must be non-zero")),
-            None => LruCache::unbounded(),
-        };
+    fn new(max_routes: usize) -> Self {
+        let routes =
+            LruCache::new(NonZeroUsize::new(max_routes).expect("max_routes must be non-zero"));
         Self {
             routes,
             progress_token_to_event: HashMap::new(),
@@ -80,7 +80,7 @@ impl Default for ServerEventRouteStore {
 impl ServerEventRouteStore {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Inner::new(None))),
+            inner: Arc::new(RwLock::new(Inner::new(DEFAULT_LRU_SIZE))),
         }
     }
 
@@ -88,7 +88,7 @@ impl ServerEventRouteStore {
     /// When the limit is reached the oldest entry is evicted.
     pub fn with_max_routes(max_routes: usize) -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Inner::new(Some(max_routes)))),
+            inner: Arc::new(RwLock::new(Inner::new(max_routes))),
         }
     }
 
@@ -302,5 +302,19 @@ mod tests {
         store.clear().await;
         assert!(store.get("e1").await.is_none());
         assert!(store.get("e2").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn default_store_is_bounded() {
+        let store = ServerEventRouteStore::new();
+        for i in 0..=DEFAULT_LRU_SIZE {
+            store
+                .register(format!("e{i}"), "pk1".into(), json!(i), None)
+                .await;
+        }
+
+        assert_eq!(store.event_route_count().await, DEFAULT_LRU_SIZE);
+        assert!(!store.has_event_route("e0").await);
+        assert!(store.has_event_route(&format!("e{DEFAULT_LRU_SIZE}")).await);
     }
 }

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -286,7 +286,9 @@ impl NostrServerTransport {
 
     /// Send a response back to the client that sent the original request.
     pub async fn send_response(&self, event_id: &str, mut response: JsonRpcMessage) -> Result<()> {
-        let client_pubkey_hex = self.event_routes.get(event_id).await.ok_or_else(|| {
+        // Consume the route up-front so only one concurrent responder can proceed
+        // for a given event_id.
+        let route = self.event_routes.pop(event_id).await.ok_or_else(|| {
             tracing::error!(
                 target: LOG_TARGET,
                 event_id = %event_id,
@@ -294,6 +296,10 @@ impl NostrServerTransport {
             );
             Error::Other(format!("No client found for event {event_id}"))
         })?;
+
+        let client_pubkey_hex = route.client_pubkey;
+        let original_request_id = route.original_request_id;
+        let progress_token = route.progress_token;
 
         let sessions = self.sessions.read().await;
         let session = sessions.get(&client_pubkey_hex).ok_or_else(|| {
@@ -306,12 +312,10 @@ impl NostrServerTransport {
         })?;
 
         // Restore original request ID
-        if let Some(original_id) = session.pending_requests.get(event_id) {
-            match &mut response {
-                JsonRpcMessage::Response(r) => r.id = original_id.clone(),
-                JsonRpcMessage::ErrorResponse(r) => r.id = original_id.clone(),
-                _ => {}
-            }
+        match &mut response {
+            JsonRpcMessage::Response(r) => r.id = original_request_id.clone(),
+            JsonRpcMessage::ErrorResponse(r) => r.id = original_request_id.clone(),
+            _ => {}
         }
 
         let is_encrypted = session.is_encrypted;
@@ -339,7 +343,8 @@ impl NostrServerTransport {
 
         let tags = BaseTransport::create_response_tags(&client_pubkey, &event_id_parsed);
 
-        self.base
+        if let Err(error) = self
+            .base
             .send_mcp_message(
                 &response,
                 &client_pubkey,
@@ -349,26 +354,35 @@ impl NostrServerTransport {
                 None,
             )
             .await
-            .map_err(|error| {
-                tracing::error!(
-                    target: LOG_TARGET,
-                    error = %error,
-                    client_pubkey = %client_pubkey_hex,
-                    event_id = %event_id,
-                    "Failed to publish response message"
-                );
-                error
-            })?;
+        {
+            tracing::error!(
+                target: LOG_TARGET,
+                error = %error,
+                client_pubkey = %client_pubkey_hex,
+                event_id = %event_id,
+                "Failed to publish response message"
+            );
 
-        // Clean up only after successful send
-        self.event_routes.pop(event_id).await;
+            // Re-register route on publish failure so caller can retry.
+            self.event_routes
+                .register(
+                    event_id.to_string(),
+                    client_pubkey_hex,
+                    original_request_id,
+                    progress_token,
+                )
+                .await;
+
+            return Err(error);
+        }
 
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(&client_pubkey_hex) {
             // Clean up progress token
-            if let Some(token) = session.event_to_progress_token.remove(event_id) {
+            if let Some(token) = progress_token {
                 session.pending_requests.remove(&token);
             }
+            session.event_to_progress_token.remove(event_id);
             session.pending_requests.remove(event_id);
         }
         drop(sessions);

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -5,9 +5,13 @@
 //! encryption-mode enforcement, and authorization) is exercised without
 //! connecting to real relays.
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
+use async_trait::async_trait;
 use contextvm_sdk::core::constants::{
     mcp_protocol_version, CTXVM_MESSAGES_KIND, GIFT_WRAP_KIND, PROMPTS_LIST_KIND,
     RESOURCES_LIST_KIND, RESOURCETEMPLATES_LIST_KIND, SERVER_ANNOUNCEMENT_KIND, TOOLS_LIST_KIND,
@@ -24,6 +28,96 @@ use nostr_sdk::prelude::*;
 
 fn as_pool(pool: MockRelayPool) -> Arc<dyn RelayPoolTrait> {
     Arc::new(pool)
+}
+
+struct TestRelayPool {
+    inner: Arc<MockRelayPool>,
+    publish_delay: Duration,
+    failures_remaining: AtomicUsize,
+    publish_attempts: AtomicUsize,
+}
+
+impl TestRelayPool {
+    fn with_publish_delay(inner: Arc<MockRelayPool>, publish_delay: Duration) -> Self {
+        Self {
+            inner,
+            publish_delay,
+            failures_remaining: AtomicUsize::new(0),
+            publish_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn with_publish_failures(inner: Arc<MockRelayPool>, failures: usize) -> Self {
+        Self {
+            inner,
+            publish_delay: Duration::ZERO,
+            failures_remaining: AtomicUsize::new(failures),
+            publish_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn publish_attempts(&self) -> usize {
+        self.publish_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl RelayPoolTrait for TestRelayPool {
+    async fn connect(&self, relay_urls: &[String]) -> contextvm_sdk::Result<()> {
+        self.inner.connect(relay_urls).await
+    }
+
+    async fn disconnect(&self) -> contextvm_sdk::Result<()> {
+        self.inner.disconnect().await
+    }
+
+    async fn publish_event(&self, event: &Event) -> contextvm_sdk::Result<EventId> {
+        if !self.publish_delay.is_zero() {
+            tokio::time::sleep(self.publish_delay).await;
+        }
+        self.publish_attempts.fetch_add(1, Ordering::SeqCst);
+        let should_fail = self
+            .failures_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok();
+
+        if should_fail {
+            return Err(contextvm_sdk::Error::Transport(
+                "injected publish failure".to_string(),
+            ));
+        }
+
+        self.inner.publish_event(event).await
+    }
+
+    async fn publish(&self, builder: EventBuilder) -> contextvm_sdk::Result<EventId> {
+        if !self.publish_delay.is_zero() {
+            tokio::time::sleep(self.publish_delay).await;
+        }
+        self.inner.publish(builder).await
+    }
+
+    async fn sign(&self, builder: EventBuilder) -> contextvm_sdk::Result<Event> {
+        self.inner.sign(builder).await
+    }
+
+    async fn signer(&self) -> contextvm_sdk::Result<Arc<dyn NostrSigner>> {
+        self.inner.signer().await
+    }
+
+    fn notifications(&self) -> tokio::sync::broadcast::Receiver<RelayPoolNotification> {
+        self.inner.notifications()
+    }
+
+    async fn public_key(&self) -> contextvm_sdk::Result<PublicKey> {
+        self.inner.public_key().await
+    }
+
+    async fn subscribe(&self, filters: Vec<Filter>) -> contextvm_sdk::Result<()> {
+        self.inner.subscribe(filters).await
+    }
 }
 
 /// Let spawned event loops call `notifications()` before we publish anything.
@@ -1794,4 +1888,234 @@ async fn response_mirrors_client_encryption_format() {
             GIFT_WRAP_KIND
         );
     }
+}
+
+// ── 26. send_response is one-shot under concurrency ────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_response_is_one_shot_under_concurrency() {
+    let (client_pool, server_pool_raw) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool_raw.mock_public_key();
+    let server_pool = Arc::new(server_pool_raw);
+
+    // Delay publish so both concurrent responders have a chance to race.
+    // Correct behavior is still one-shot: exactly one send_response succeeds.
+    let delayed_server_pool: Arc<dyn RelayPoolTrait> = Arc::new(TestRelayPool::with_publish_delay(
+        Arc::clone(&server_pool),
+        Duration::from_millis(25),
+    ));
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        delayed_server_pool,
+    )
+    .await
+    .expect("create server transport");
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .expect("create client transport");
+
+    let mut server_rx = server
+        .take_message_receiver()
+        .expect("server message receiver");
+    let mut client_rx = client
+        .take_message_receiver()
+        .expect("client message receiver");
+
+    server.start().await.expect("server start");
+    client.start().await.expect("client start");
+    let_event_loops_start().await;
+
+    let request = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!("one-shot-req"),
+        method: "tools/list".to_string(),
+        params: None,
+    });
+    client.send(&request).await.expect("send request");
+
+    let incoming = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .expect("timeout waiting for server to receive request")
+        .expect("server channel closed");
+
+    let response = JsonRpcMessage::Response(JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!("placeholder"),
+        result: serde_json::json!({ "one_shot": "ok" }),
+    });
+
+    let event_id = incoming.event_id.clone();
+    let f1 = server.send_response(&event_id, response.clone());
+    let f2 = server.send_response(&event_id, response);
+    let (r1, r2) = tokio::join!(f1, f2);
+
+    assert_ne!(
+        r1.is_ok(),
+        r2.is_ok(),
+        "exactly one concurrent send_response call must succeed"
+    );
+
+    let msg = tokio::time::timeout(Duration::from_millis(500), client_rx.recv())
+        .await
+        .expect("timeout waiting for client to receive response")
+        .expect("client channel closed");
+    assert!(msg.is_response(), "client must receive one response");
+    assert_eq!(
+        msg.id(),
+        Some(&serde_json::json!("one-shot-req")),
+        "server must restore original request id in response"
+    );
+
+    let second = tokio::time::timeout(Duration::from_millis(200), client_rx.recv()).await;
+    assert!(
+        second.is_err(),
+        "client must not receive duplicate response"
+    );
+
+    let events = server_pool.stored_events().await;
+    let response_events = events
+        .iter()
+        .filter(|e| e.pubkey == server_pubkey && e.content.contains("\"one_shot\":\"ok\""))
+        .count();
+    assert_eq!(
+        response_events, 1,
+        "only one response event must be published"
+    );
+}
+
+// ── 27. send_response publish failure allows retry ─────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_response_publish_failure_allows_one_successful_retry() {
+    let (client_pool, server_pool_raw) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool_raw.mock_public_key();
+    let server_pool = Arc::new(server_pool_raw);
+    let failing_server_pool = Arc::new(TestRelayPool::with_publish_failures(
+        Arc::clone(&server_pool),
+        1,
+    ));
+    
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        Arc::clone(&failing_server_pool) as Arc<dyn RelayPoolTrait>,
+    )
+    .await
+    .expect("create server transport");
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .expect("create client transport");
+
+    let mut server_rx = server
+        .take_message_receiver()
+        .expect("server message receiver");
+    let mut client_rx = client
+        .take_message_receiver()
+        .expect("client message receiver");
+
+    server.start().await.expect("server start");
+    client.start().await.expect("client start");
+    let_event_loops_start().await;
+
+    let request = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!("retry-once"),
+        method: "tools/list".to_string(),
+        params: None,
+    });
+    client.send(&request).await.expect("send request");
+
+    let incoming = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .expect("timeout waiting for server request")
+        .expect("server channel closed");
+    assert_eq!(incoming.message.method(), Some("tools/list"));
+
+    let response = JsonRpcMessage::Response(JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!("placeholder"),
+        result: serde_json::json!({ "tools": [] }),
+    });
+
+    let stored_before_failure = server_pool.stored_events().await.len();
+    server
+        .send_response(&incoming.event_id, response.clone())
+        .await
+        .expect_err("first response publish must fail");
+
+    assert_eq!(
+        failing_server_pool.publish_attempts(),
+        1,
+        "failed response should attempt exactly one publish"
+    );
+    assert_eq!(
+        server_pool.stored_events().await.len(),
+        stored_before_failure,
+        "failed publish must not store a response event"
+    );
+
+    server
+        .send_response(&incoming.event_id, response.clone())
+        .await
+        .expect("retry must still find the route and publish");
+
+    let client_msg = tokio::time::timeout(Duration::from_millis(500), client_rx.recv())
+        .await
+        .expect("timeout waiting for retried response")
+        .expect("client channel closed");
+    assert!(client_msg.is_response());
+    assert_eq!(client_msg.id(), Some(&serde_json::json!("retry-once")));
+    assert_eq!(
+        failing_server_pool.publish_attempts(),
+        2,
+        "retry should perform the second and final publish"
+    );
+    assert_eq!(
+        server_pool.stored_events().await.len(),
+        stored_before_failure + 1,
+        "successful retry must publish exactly one response event"
+    );
+
+    server
+        .send_response(&incoming.event_id, response)
+        .await
+        .expect_err("route must be consumed after the successful retry");
+    assert_eq!(
+        failing_server_pool.publish_attempts(),
+        2,
+        "consumed route should fail before another publish attempt"
+    );
+    assert_eq!(
+        server_pool.stored_events().await.len(),
+        stored_before_failure + 1,
+        "post-success retry must not publish another response"
+    );
+
+    let second_delivery = tokio::time::timeout(Duration::from_millis(50), client_rx.recv()).await;
+    assert!(
+        second_delivery.is_err(),
+        "client must receive the retried response exactly once"
+    );
 }


### PR DESCRIPTION
This PR solves #47 
Changes made:
- Updated send_response to consume route state up front by popping the route first. This matches the behaviour in Ts sdk
- Restored original request ID from popped route metadata instead of re-reading route state
- Added publish-failure recovery

Tests are added force this race condition and check the behaviour