### PR TITLE
fix (bug): send JSON-RPC -32000 Unauthorized error on announced servers with allowlist

### DIFF
--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -224,6 +224,7 @@ impl NostrServerTransport {
         let allowed = self.config.allowed_public_keys.clone();
         let excluded = self.config.excluded_capabilities.clone();
         let encryption_mode = self.config.encryption_mode;
+        let is_announced_server = self.config.is_announced_server;
         let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
 
         tokio::spawn(async move {
@@ -235,6 +236,7 @@ impl NostrServerTransport {
                 allowed,
                 excluded,
                 encryption_mode,
+                is_announced_server,
                 seen_gift_wrap_ids,
             )
             .await;
@@ -656,6 +658,7 @@ impl NostrServerTransport {
         allowed_pubkeys: Vec<String>,
         excluded_capabilities: Vec<CapabilityExclusion>,
         encryption_mode: EncryptionMode,
+        is_announced_server: bool,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     ) {
         let mut notifications = relay_pool.notifications();
@@ -799,6 +802,57 @@ impl NostrServerTransport {
                             method = method,
                             "Unauthorized request"
                         );
+
+                        // On announced servers, send a JSON-RPC error back for
+                        // Request messages so the client doesn't hang indefinitely.
+                        if is_announced_server {
+                            if let JsonRpcMessage::Request(ref req) = mcp_msg {
+                                let error_response =
+                                    JsonRpcMessage::ErrorResponse(JsonRpcErrorResponse {
+                                        jsonrpc: "2.0".to_string(),
+                                        id: req.id.clone(),
+                                        error: JsonRpcError {
+                                            code: -32000,
+                                            message: "Unauthorized".to_string(),
+                                            data: None,
+                                        },
+                                    });
+
+                                if let Ok(client_pk) = PublicKey::from_hex(&sender_pubkey) {
+                                    let event_id_parsed = EventId::from_hex(&event_id)
+                                        .unwrap_or(EventId::all_zeros());
+                                    let tags = BaseTransport::create_response_tags(
+                                        &client_pk,
+                                        &event_id_parsed,
+                                    );
+
+                                    let base = BaseTransport {
+                                        relay_pool: Arc::clone(&relay_pool),
+                                        encryption_mode,
+                                        is_connected: true,
+                                    };
+                                    if let Err(e) = base
+                                        .send_mcp_message(
+                                            &error_response,
+                                            &client_pk,
+                                            CTXVM_MESSAGES_KIND,
+                                            tags,
+                                            Some(is_encrypted),
+                                            None,
+                                        )
+                                        .await
+                                    {
+                                        tracing::error!(
+                                            target: LOG_TARGET,
+                                            error = %e,
+                                            sender_pubkey = %sender_pubkey,
+                                            "Failed to send unauthorized error response"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
                         continue;
                     }
                 }

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -2119,3 +2119,213 @@ async fn send_response_publish_failure_allows_one_successful_retry() {
         "client must receive the retried response exactly once"
     );
 }
+
+// ── 28. Announced server sends unauthorized error response ───────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn announced_server_sends_unauthorized_error_response() {
+    let allowed_keys = Keys::generate(); // a DIFFERENT pubkey — client is NOT in the allowlist
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+
+    // Announced server with an allowlist that does NOT include the client.
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
+            is_announced_server: true,
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(server_pool),
+    )
+    .await
+    .expect("create server transport");
+
+    let mut server_rx = server
+        .take_message_receiver()
+        .expect("server message receiver");
+    server.start().await.expect("server start");
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .expect("create client transport");
+
+    let mut client_rx = client
+        .take_message_receiver()
+        .expect("client message receiver");
+    client.start().await.expect("client start");
+    let_event_loops_start().await;
+
+    // Send a non-initialize request from the unauthorized client.
+    let request = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(42),
+        method: "tools/list".to_string(),
+        params: None,
+    });
+    client.send(&request).await.expect("send request");
+
+    // The server handler must NOT receive the request (it's unauthorized).
+    let server_forward = tokio::time::timeout(Duration::from_millis(300), server_rx.recv()).await;
+    assert!(
+        server_forward.is_err(),
+        "unauthorized request must not reach the server handler"
+    );
+
+    // The client MUST receive a -32000 Unauthorized error response.
+    let error_msg = tokio::time::timeout(Duration::from_millis(500), client_rx.recv())
+        .await
+        .expect("timeout waiting for unauthorized error response")
+        .expect("client channel closed");
+
+    match error_msg {
+        JsonRpcMessage::ErrorResponse(err) => {
+            assert_eq!(err.error.code, -32000, "error code must be -32000");
+            assert_eq!(
+                err.error.message, "Unauthorized",
+                "error message must be 'Unauthorized'"
+            );
+        }
+        other => panic!(
+            "expected ErrorResponse, got: {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+}
+
+// ── 29. Private server silently drops unauthorized request ───────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn private_server_silently_drops_unauthorized_request() {
+    let allowed_keys = Keys::generate();
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+
+    // Private server (is_announced_server defaults to false).
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(server_pool),
+    )
+    .await
+    .expect("create server transport");
+
+    let mut server_rx = server
+        .take_message_receiver()
+        .expect("server message receiver");
+    server.start().await.expect("server start");
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .expect("create client transport");
+
+    let mut client_rx = client
+        .take_message_receiver()
+        .expect("client message receiver");
+    client.start().await.expect("client start");
+    let_event_loops_start().await;
+
+    let request = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(99),
+        method: "tools/list".to_string(),
+        params: None,
+    });
+    client.send(&request).await.expect("send request");
+
+    // Server handler must not receive it.
+    let server_forward = tokio::time::timeout(Duration::from_millis(300), server_rx.recv()).await;
+    assert!(
+        server_forward.is_err(),
+        "unauthorized request must not reach the server handler"
+    );
+
+    // Client must NOT receive any error response (private server silently drops).
+    let client_response = tokio::time::timeout(Duration::from_millis(300), client_rx.recv()).await;
+    assert!(
+        client_response.is_err(),
+        "private server must silently drop unauthorized requests without sending an error"
+    );
+}
+
+// ── 30. Announced server does not error on unauthorized notification ─────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn announced_server_does_not_error_on_unauthorized_notification() {
+    let allowed_keys = Keys::generate();
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
+            is_announced_server: true,
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(server_pool),
+    )
+    .await
+    .expect("create server transport");
+
+    let mut server_rx = server
+        .take_message_receiver()
+        .expect("server message receiver");
+    server.start().await.expect("server start");
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .expect("create client transport");
+
+    let mut client_rx = client
+        .take_message_receiver()
+        .expect("client message receiver");
+    client.start().await.expect("client start");
+    let_event_loops_start().await;
+
+    // Send a notification (not a request) from the unauthorized client.
+    let notification = JsonRpcMessage::Notification(JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "notifications/progress".to_string(),
+        params: None,
+    });
+    client.send(&notification).await.expect("send notification");
+
+    // Server handler must not receive the notification.
+    let server_forward = tokio::time::timeout(Duration::from_millis(300), server_rx.recv()).await;
+    assert!(
+        server_forward.is_err(),
+        "unauthorized notification must not reach the server handler"
+    );
+
+    // Client must NOT receive an error (notifications never get error replies).
+    let client_response = tokio::time::timeout(Duration::from_millis(300), client_rx.recv()).await;
+    assert!(
+        client_response.is_err(),
+        "announced server must not send error response for unauthorized notifications"
+    );
+}


### PR DESCRIPTION
Fixes #52 

Announced servers with an allowlist were silently dropping requests from unauthorized clients after initialization completed. Since initialize is always allowed, clients could complete the handshake and then hang indefinitely waiting for a response that never comes.

The TS SDK sends a -32000 Unauthorized JSON-RPC error in this case. This PR matches that behavior, only for announced servers. Private servers still silently drop as before.

Three integration tests added covering:
- Announced server sends -32000 to unauthorized client
- Private server silently drops (no error)
- Announced server does not error on unauthorized notifications