### PR TITLE
fix (bug): register client request before publish and drop uncorrelated responses

### DIFF
--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -101,6 +101,58 @@ impl BaseTransport {
         self.relay_pool.sign(builder).await
     }
 
+    /// Prepare an MCP message for publishing without actually publishing it.
+    ///
+    /// Signs (and optionally gift-wraps) the event, returning the inner signed
+    /// event ID together with the final event that should be published to relays.
+    pub async fn prepare_mcp_message(
+        &self,
+        message: &JsonRpcMessage,
+        recipient: &PublicKey,
+        kind: u16,
+        tags: Vec<Tag>,
+        is_encrypted: Option<bool>,
+        gift_wrap_kind: Option<u16>,
+    ) -> Result<(EventId, Event)> {
+        let should_encrypt = self.should_encrypt(kind, is_encrypted);
+
+        let event = self.create_signed_event(message, kind, tags).await?;
+        let signed_event_id = event.id;
+
+        if should_encrypt {
+            let event_json =
+                serde_json::to_string(&event).map_err(|e| Error::Encryption(e.to_string()))?;
+            let signer = self
+                .relay_pool
+                .signer()
+                .await
+                .map_err(|e| Error::Encryption(e.to_string()))?;
+            let selected_gift_wrap_kind = gift_wrap_kind.unwrap_or(GIFT_WRAP_KIND);
+            let gift_wrap_event = encryption::gift_wrap_single_layer_with_kind(
+                &signer,
+                recipient,
+                &event_json,
+                selected_gift_wrap_kind,
+            )
+            .await?;
+            tracing::debug!(
+                target: LOG_TARGET,
+                signed_event_id = %signed_event_id,
+                envelope_id = %gift_wrap_event.id,
+                gift_wrap_kind = selected_gift_wrap_kind,
+                "Prepared encrypted MCP message"
+            );
+            Ok((signed_event_id, gift_wrap_event))
+        } else {
+            tracing::debug!(
+                target: LOG_TARGET,
+                signed_event_id = %signed_event_id,
+                "Prepared unencrypted MCP message"
+            );
+            Ok((signed_event_id, event))
+        }
+    }
+
     /// Send an MCP message to a recipient, optionally encrypting.
     ///
     /// Returns the signed MCP event ID.

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -274,9 +274,10 @@ impl NostrClientTransport {
         }
 
         let tags = BaseTransport::create_recipient_tags(&self.server_pubkey);
-        let event_id = self
+
+        let (event_id, publishable_event) = self
             .base
-            .send_mcp_message(
+            .prepare_mcp_message(
                 message,
                 &self.server_pubkey,
                 CTXVM_MESSAGES_KIND,
@@ -291,7 +292,7 @@ impl NostrClientTransport {
                     error = %error,
                     server_pubkey = %self.server_pubkey.to_hex(),
                     method = ?message.method(),
-                    "Failed to send client message"
+                    "Failed to prepare client message"
                 );
                 error
             })?;
@@ -301,6 +302,18 @@ impl NostrClientTransport {
             self.pending_requests
                 .register(event_id.to_hex(), req.id.clone(), is_initialize)
                 .await;
+        }
+
+        if let Err(error) = self.base.relay_pool.publish_event(&publishable_event).await {
+            self.pending_requests.remove(&event_id.to_hex()).await;
+            tracing::error!(
+                target: LOG_TARGET,
+                error = %error,
+                server_pubkey = %self.server_pubkey.to_hex(),
+                method = ?message.method(),
+                "Failed to publish client message"
+            );
+            return Err(error);
         }
 
         tracing::debug!(
@@ -502,6 +515,28 @@ impl NostrClientTransport {
 
                 // Parse MCP message
                 if let Some(mcp_msg) = validation::validate_and_parse(&actual_event_content) {
+                    // Drop uncorrelated responses and server-to-client requests (matches TS SDK).
+                    match &mcp_msg {
+                        JsonRpcMessage::Response(_) | JsonRpcMessage::ErrorResponse(_)
+                            if e_tag.is_none() =>
+                        {
+                            tracing::warn!(
+                                target: LOG_TARGET,
+                                "Dropping response/error without correlation `e` tag"
+                            );
+                            continue;
+                        }
+                        JsonRpcMessage::Request(_) => {
+                            tracing::warn!(
+                                target: LOG_TARGET,
+                                method = ?mcp_msg.method(),
+                                "Dropping server-to-client request (invalid in MCP)"
+                            );
+                            continue;
+                        }
+                        _ => {}
+                    }
+
                     // Clean up pending request
                     if let Some(ref correlated_id) = e_tag {
                         pending.remove(correlated_id.as_str()).await;


### PR DESCRIPTION
Fixes #54 

Two client transport bugs fixed:

1. send() published to relays before registering the request in pending_requests. A fast server response could arrive before registration and get silently dropped. Fixed by splitting into prepare → register → publish.

2. Response/ErrorResponse without an e tag and server-to-client requests were forwarded to the consumer uncorrelated. Now dropped to match TS SDK behavior.

