### PR TITLE
feat: add tag composition, server discovery tag emission and capability learning for CEP-35

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -91,10 +91,16 @@ pub struct ClientSession {
     pub is_initialized: bool,
     /// Whether the client's messages were encrypted.
     pub is_encrypted: bool,
-    /// Whether common discovery tags have been sent to this client.
+    /// Whether server discovery tags have been sent to this client (one-shot flag).
     pub has_sent_common_tags: bool,
-    /// Whether the client has demonstrated support for ephemeral gift wraps.
+    /// Whether the client has demonstrated support for ephemeral gift wraps (CEP-19).
     pub supports_ephemeral_gift_wrap: bool,
+    /// Learned from client discovery tags: peer supports NIP-44 encryption.
+    pub supports_encryption: bool,
+    /// Learned from client discovery tags: peer supports ephemeral gift wraps (CEP-19).
+    pub supports_ephemeral_encryption: bool,
+    /// Learned from client discovery tags: peer supports CEP-22 oversized transfer.
+    pub supports_oversized_transfer: bool,
     /// Last activity timestamp.
     pub last_activity: Instant,
     /// Pending requests: event_id → original request ID.
@@ -111,6 +117,9 @@ impl ClientSession {
             is_encrypted,
             has_sent_common_tags: false,
             supports_ephemeral_gift_wrap: false,
+            supports_encryption: false,
+            supports_ephemeral_encryption: false,
+            supports_oversized_transfer: false,
             last_activity: Instant::now(),
             pending_requests: HashMap::new(),
             event_to_progress_token: HashMap::new(),

--- a/src/transport/base.rs
+++ b/src/transport/base.rs
@@ -232,6 +232,21 @@ impl BaseTransport {
     pub fn create_response_tags(pubkey: &PublicKey, event_id: &EventId) -> Vec<Tag> {
         vec![Tag::public_key(*pubkey), Tag::event(*event_id)]
     }
+
+    /// Compose outbound event tags in canonical order:
+    /// routing (p, e) -> discovery (one-shot caps) -> negotiation (pmi, persistent).
+    pub fn compose_outbound_tags(
+        base_tags: &[Tag],
+        discovery_tags: &[Tag],
+        negotiation_tags: &[Tag],
+    ) -> Vec<Tag> {
+        let mut tags =
+            Vec::with_capacity(base_tags.len() + discovery_tags.len() + negotiation_tags.len());
+        tags.extend_from_slice(base_tags);
+        tags.extend_from_slice(discovery_tags);
+        tags.extend_from_slice(negotiation_tags);
+        tags
+    }
 }
 
 #[cfg(test)]
@@ -395,5 +410,58 @@ mod tests {
     fn test_convert_event_to_mcp_oversized_message() {
         let big = "x".repeat(MAX_MESSAGE_SIZE + 1);
         assert!(!crate::core::validation::validate_message_size(&big));
+    }
+
+    // ── compose_outbound_tags ──────────────────────────────────
+
+    fn make_custom_tag(name: &str) -> Tag {
+        Tag::custom(TagKind::Custom(name.into()), Vec::<String>::new())
+    }
+
+    #[test]
+    fn compose_outbound_tags_ordering() {
+        let keys = Keys::generate();
+        let base = vec![Tag::public_key(keys.public_key())];
+        let discovery = vec![make_custom_tag("support_encryption")];
+        let negotiation = vec![make_custom_tag("pmi")];
+
+        let result = BaseTransport::compose_outbound_tags(&base, &discovery, &negotiation);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].clone().to_vec()[0], "p");
+        assert_eq!(result[1].clone().to_vec()[0], "support_encryption");
+        assert_eq!(result[2].clone().to_vec()[0], "pmi");
+    }
+
+    #[test]
+    fn compose_outbound_tags_empty_discovery() {
+        let keys = Keys::generate();
+        let base = vec![Tag::public_key(keys.public_key())];
+        let negotiation = vec![make_custom_tag("pmi")];
+
+        let result = BaseTransport::compose_outbound_tags(&base, &[], &negotiation);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].clone().to_vec()[0], "p");
+        assert_eq!(result[1].clone().to_vec()[0], "pmi");
+    }
+
+    #[test]
+    fn compose_outbound_tags_all_empty() {
+        let result = BaseTransport::compose_outbound_tags(&[], &[], &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn compose_outbound_tags_preserves_all_elements() {
+        let discovery = vec![
+            make_custom_tag("support_encryption"),
+            make_custom_tag("support_encryption_ephemeral"),
+        ];
+        let result = BaseTransport::compose_outbound_tags(&[], &discovery, &[]);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].clone().to_vec()[0], "support_encryption");
+        assert_eq!(
+            result[1].clone().to_vec()[0],
+            "support_encryption_ephemeral"
+        );
     }
 }

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -26,6 +26,7 @@ use crate::core::validation;
 use crate::encryption;
 use crate::relay::{RelayPool, RelayPoolTrait};
 use crate::transport::base::BaseTransport;
+use crate::transport::discovery_tags::learn_peer_capabilities;
 
 use crate::util::tracing_setup;
 
@@ -333,8 +334,8 @@ impl NostrServerTransport {
         let original_request_id = route.original_request_id;
         let progress_token = route.progress_token;
 
-        let sessions = self.sessions.read().await;
-        let session = sessions.get(&client_pubkey_hex).ok_or_else(|| {
+        let mut sessions_w = self.sessions.write().await;
+        let session = sessions_w.get_mut(&client_pubkey_hex).ok_or_else(|| {
             tracing::error!(
                 target: LOG_TARGET,
                 client_pubkey = %client_pubkey_hex,
@@ -351,7 +352,10 @@ impl NostrServerTransport {
         }
 
         let is_encrypted = session.is_encrypted;
-        drop(sessions);
+
+        // CEP-35: include discovery tags on first response to this client
+        let discovery_tags = self.take_pending_server_discovery_tags(session);
+        drop(sessions_w);
 
         // CEP-19: Look up the incoming wrap kind for mirroring
         let mirrored_wrap_kind = self
@@ -382,23 +386,8 @@ impl NostrServerTransport {
             Error::Other(error.to_string())
         })?;
 
-        let mut tags = BaseTransport::create_response_tags(&client_pubkey, &event_id_parsed);
-
-        // Send server info and capabilities on the first response.
-        let mut sent_common_tags = false;
-        let session_snapshot = self.sessions.get_session(&client_pubkey_hex).await;
-        if let Some(snap) = session_snapshot {
-            if !snap.has_sent_common_tags {
-                Self::append_common_response_tags(
-                    &mut tags,
-                    self.config.server_info.as_ref(),
-                    &self.extra_common_tags,
-                    self.config.encryption_mode,
-                    self.config.gift_wrap_mode,
-                );
-                sent_common_tags = true;
-            }
-        }
+        let base_tags = BaseTransport::create_response_tags(&client_pubkey, &event_id_parsed);
+        let tags = BaseTransport::compose_outbound_tags(&base_tags, &discovery_tags, &[]);
 
         if let Err(error) = self
             .base
@@ -437,16 +426,7 @@ impl NostrServerTransport {
             return Err(error);
         }
 
-        if sent_common_tags {
-            self.sessions
-                .mark_common_tags_sent(&client_pubkey_hex)
-                .await;
-        }
-
-        // Clean up only after successful send
-        self.event_routes.pop(event_id).await;
-
-        // Clean up wrap-kind tracking and reverse mapping
+        // Clean up wrap-kind tracking
         self.request_wrap_kinds.write().await.remove(event_id);
 
         let mut sessions = self.sessions.write().await;
@@ -477,22 +457,27 @@ impl NostrServerTransport {
         notification: &JsonRpcMessage,
         correlated_event_id: Option<&str>,
     ) -> Result<()> {
-        let sessions = self.sessions.read().await;
+        let mut sessions = self.sessions.write().await;
         let session = sessions
-            .get(client_pubkey_hex)
+            .get_mut(client_pubkey_hex)
             .ok_or_else(|| Error::Other(format!("No session for {client_pubkey_hex}")))?;
         let is_encrypted = session.is_encrypted;
         let supports_ephemeral = session.supports_ephemeral_gift_wrap;
+
+        // CEP-35: include discovery tags on first message to this client
+        let discovery_tags = self.take_pending_server_discovery_tags(session);
         drop(sessions);
 
         let client_pubkey =
             PublicKey::from_hex(client_pubkey_hex).map_err(|e| Error::Other(e.to_string()))?;
 
-        let mut tags = BaseTransport::create_recipient_tags(&client_pubkey);
+        let mut base_tags = BaseTransport::create_recipient_tags(&client_pubkey);
         if let Some(eid) = correlated_event_id {
             let event_id = EventId::from_hex(eid).map_err(|e| Error::Other(e.to_string()))?;
-            tags.push(Tag::event(event_id));
+            base_tags.push(Tag::event(event_id));
         }
+
+        let tags = BaseTransport::compose_outbound_tags(&base_tags, &discovery_tags, &[]);
 
         // CEP-19: Look up mirrored wrap kind from correlated request
         let correlated_wrap_kind = if let Some(event_id) = correlated_event_id {
@@ -732,6 +717,70 @@ impl NostrServerTransport {
         self.publish_resource_templates(templates).await
     }
 
+    // ── CEP-35 discovery tag helpers ──────────────────────────────
+
+    /// Build common discovery tags from server config.
+    ///
+    /// Includes server info tags (name, about, website, picture) and capability
+    /// tags (support_encryption, support_encryption_ephemeral) based on the
+    /// transport's encryption and gift-wrap mode.
+    fn get_common_tags(&self) -> Vec<Tag> {
+        let mut tags = Vec::new();
+
+        // Server info tags
+        if let Some(ref info) = self.config.server_info {
+            if let Some(ref name) = info.name {
+                tags.push(Tag::custom(
+                    TagKind::Custom(tags::NAME.into()),
+                    vec![name.clone()],
+                ));
+            }
+            if let Some(ref about) = info.about {
+                tags.push(Tag::custom(
+                    TagKind::Custom(tags::ABOUT.into()),
+                    vec![about.clone()],
+                ));
+            }
+            if let Some(ref website) = info.website {
+                tags.push(Tag::custom(
+                    TagKind::Custom(tags::WEBSITE.into()),
+                    vec![website.clone()],
+                ));
+            }
+            if let Some(ref picture) = info.picture {
+                tags.push(Tag::custom(
+                    TagKind::Custom(tags::PICTURE.into()),
+                    vec![picture.clone()],
+                ));
+            }
+        }
+
+        // Capability tags
+        if self.config.encryption_mode != EncryptionMode::Disabled {
+            tags.push(Tag::custom(
+                TagKind::Custom(tags::SUPPORT_ENCRYPTION.into()),
+                Vec::<String>::new(),
+            ));
+            if self.config.gift_wrap_mode.supports_ephemeral() {
+                tags.push(Tag::custom(
+                    TagKind::Custom(tags::SUPPORT_ENCRYPTION_EPHEMERAL.into()),
+                    Vec::<String>::new(),
+                ));
+            }
+        }
+
+        tags
+    }
+
+    /// One-shot: returns common tags if not yet sent to this client, empty otherwise.
+    fn take_pending_server_discovery_tags(&self, session: &mut ClientSession) -> Vec<Tag> {
+        if session.has_sent_common_tags {
+            return vec![];
+        }
+        session.has_sent_common_tags = true;
+        self.get_common_tags()
+    }
+
     // ── Internal ────────────────────────────────────────────────
 
     fn is_capability_excluded(
@@ -792,7 +841,7 @@ impl NostrServerTransport {
                     continue;
                 }
 
-                let (content, sender_pubkey, event_id, is_encrypted) = if is_gift_wrap {
+                let (content, sender_pubkey, event_id, is_encrypted, inner_tags) = if is_gift_wrap {
                     if encryption_mode == EncryptionMode::Disabled {
                         tracing::warn!(
                             target: LOG_TARGET,
@@ -848,11 +897,13 @@ impl NostrServerTransport {
                                         };
                                         guard.put(event.id, ());
                                     }
+                                    let inner_tags: Vec<Tag> = inner.tags.to_vec();
                                     (
                                         inner.content,
                                         inner.pubkey.to_hex(),
                                         inner.id.to_hex(),
                                         true,
+                                        inner_tags,
                                     )
                                 }
                                 Err(error) => {
@@ -888,6 +939,7 @@ impl NostrServerTransport {
                         event.pubkey.to_hex(),
                         event.id.to_hex(),
                         false,
+                        event.tags.to_vec(),
                     )
                 };
 
@@ -1013,6 +1065,16 @@ impl NostrServerTransport {
                 if is_gift_wrap && outer_kind == EPHEMERAL_GIFT_WRAP_KIND {
                     session.supports_ephemeral_gift_wrap = true;
                 }
+
+                // CEP-35: learn client capabilities from inner event tags
+                let discovered = learn_peer_capabilities(&inner_tags);
+                session.supports_encryption |= discovered.supports_encryption;
+                session.supports_ephemeral_encryption |= discovered.supports_ephemeral_encryption;
+                // Only learn oversized support if CEP-22 is enabled on this server
+                // TODO: wire from config when CEP-22 lands
+                let oversized_enabled = false;
+                session.supports_oversized_transfer |=
+                    oversized_enabled && discovered.supports_oversized_transfer;
 
                 // Track request for correlation
                 if let JsonRpcMessage::Request(ref req) = mcp_msg {
@@ -1449,7 +1511,6 @@ mod tests {
 
     #[test]
     fn test_select_outbound_gift_wrap_kind_plaintext() {
-        // Plaintext: no encryption regardless of mode
         assert_eq!(
             NostrServerTransport::select_outbound_gift_wrap_kind(
                 GiftWrapMode::Optional,
@@ -1462,7 +1523,6 @@ mod tests {
 
     #[test]
     fn test_select_outbound_gift_wrap_kind_mirrors_incoming() {
-        // Mirrors ephemeral kind when Optional mode allows it
         assert_eq!(
             NostrServerTransport::select_outbound_gift_wrap_kind(
                 GiftWrapMode::Optional,
@@ -1475,7 +1535,6 @@ mod tests {
 
     #[test]
     fn test_select_outbound_gift_wrap_kind_persistent_mode_overrides_ephemeral() {
-        // Persistent mode: ephemeral mirror ignored, falls back to GIFT_WRAP_KIND
         assert_eq!(
             NostrServerTransport::select_outbound_gift_wrap_kind(
                 GiftWrapMode::Persistent,
@@ -1659,5 +1718,37 @@ mod tests {
             .find(|t| (*t).clone().to_vec().first().map(|s| s.as_str()) == Some("custom_tag"))
             .and_then(|t| t.clone().to_vec().get(1).cloned());
         assert_eq!(tag_value.as_deref(), Some("value"));
+    }
+
+    // ── CEP-35 discovery tag helpers ────────────────────────────
+
+    #[test]
+    fn test_cep35_client_session_new_fields_default_false() {
+        let session = ClientSession::new(false);
+        assert!(!session.has_sent_common_tags);
+        assert!(!session.supports_encryption);
+        assert!(!session.supports_ephemeral_encryption);
+        assert!(!session.supports_oversized_transfer);
+    }
+
+    #[test]
+    fn test_cep35_capability_or_assign() {
+        let mut session = ClientSession::new(false);
+
+        session.supports_encryption |= true;
+        session.supports_ephemeral_encryption |= false;
+
+        session.supports_encryption |= false;
+        session.supports_ephemeral_encryption |= true;
+
+        assert!(session.supports_encryption, "OR-assign must not downgrade");
+        assert!(session.supports_ephemeral_encryption);
+        assert!(!session.supports_oversized_transfer);
+    }
+
+    #[test]
+    fn test_config_gift_wrap_mode_default() {
+        let config = NostrServerTransportConfig::default();
+        assert_eq!(config.gift_wrap_mode, GiftWrapMode::Optional);
     }
 }

--- a/src/transport/server/session_store.rs
+++ b/src/transport/server/session_store.rs
@@ -218,4 +218,124 @@ mod tests {
         assert!(keys.contains(&"client-1"));
         assert!(keys.contains(&"client-2"));
     }
+
+    // ── CEP-35 capability fields ────────────────────────────────
+
+    #[tokio::test]
+    async fn new_session_capability_fields_default_false() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        let sessions = store.read().await;
+        let session = sessions.get("client-1").unwrap();
+        assert!(!session.has_sent_common_tags);
+        assert!(!session.supports_encryption);
+        assert!(!session.supports_ephemeral_encryption);
+        assert!(!session.supports_oversized_transfer);
+    }
+
+    #[tokio::test]
+    async fn has_sent_common_tags_flag() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        let mut sessions = store.write().await;
+        let session = sessions.get_mut("client-1").unwrap();
+        assert!(!session.has_sent_common_tags);
+        session.has_sent_common_tags = true;
+        assert!(session.has_sent_common_tags);
+    }
+
+    #[tokio::test]
+    async fn capability_or_assign_persists() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        // First update: learn encryption support
+        {
+            let mut sessions = store.write().await;
+            let session = sessions.get_mut("client-1").unwrap();
+            session.supports_encryption |= true;
+            session.supports_ephemeral_encryption |= false;
+        }
+
+        // Second update: learn ephemeral support; encryption stays true
+        {
+            let mut sessions = store.write().await;
+            let session = sessions.get_mut("client-1").unwrap();
+            session.supports_encryption |= false; // should stay true
+            session.supports_ephemeral_encryption |= true;
+        }
+
+        let sessions = store.read().await;
+        let session = sessions.get("client-1").unwrap();
+        assert!(session.supports_encryption, "OR-assign must not downgrade");
+        assert!(session.supports_ephemeral_encryption);
+        assert!(!session.supports_oversized_transfer);
+    }
+
+    #[tokio::test]
+    async fn capability_fields_independent_per_client() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-a", false).await;
+        store.get_or_create_session("client-b", false).await;
+
+        {
+            let mut sessions = store.write().await;
+            let sa = sessions.get_mut("client-a").unwrap();
+            sa.supports_encryption = true;
+            sa.has_sent_common_tags = true;
+        }
+
+        let sessions = store.read().await;
+        let sa = sessions.get("client-a").unwrap();
+        let sb = sessions.get("client-b").unwrap();
+        assert!(sa.supports_encryption);
+        assert!(sa.has_sent_common_tags);
+        assert!(!sb.supports_encryption);
+        assert!(!sb.has_sent_common_tags);
+    }
+
+    #[tokio::test]
+    async fn get_or_create_preserves_capability_fields() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+
+        // Set capability fields
+        {
+            let mut sessions = store.write().await;
+            let session = sessions.get_mut("client-1").unwrap();
+            session.supports_encryption = true;
+            session.has_sent_common_tags = true;
+        }
+
+        // Re-enter via get_or_create (existing session)
+        let created = store.get_or_create_session("client-1", true).await;
+        assert!(!created);
+
+        // Capability fields must survive
+        let sessions = store.read().await;
+        let session = sessions.get("client-1").unwrap();
+        assert!(session.supports_encryption);
+        assert!(session.has_sent_common_tags);
+    }
+
+    #[tokio::test]
+    async fn clear_resets_capability_fields() {
+        let store = SessionStore::new();
+        store.get_or_create_session("client-1", false).await;
+        {
+            let mut sessions = store.write().await;
+            let s = sessions.get_mut("client-1").unwrap();
+            s.supports_encryption = true;
+        }
+
+        store.clear().await;
+        store.get_or_create_session("client-1", false).await;
+
+        let sessions = store.read().await;
+        let session = sessions.get("client-1").unwrap();
+        assert!(!session.supports_encryption);
+        assert!(!session.has_sent_common_tags);
+    }
 }

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -12,11 +12,13 @@ use std::sync::{
 use std::time::Duration;
 
 use async_trait::async_trait;
+use contextvm_sdk::core::constants::tags;
 use contextvm_sdk::core::constants::{
-    mcp_protocol_version, CTXVM_MESSAGES_KIND, GIFT_WRAP_KIND, PROMPTS_LIST_KIND,
-    RESOURCES_LIST_KIND, RESOURCETEMPLATES_LIST_KIND, SERVER_ANNOUNCEMENT_KIND, TOOLS_LIST_KIND,
+    mcp_protocol_version, CTXVM_MESSAGES_KIND, EPHEMERAL_GIFT_WRAP_KIND, GIFT_WRAP_KIND,
+    PROMPTS_LIST_KIND, RESOURCES_LIST_KIND, RESOURCETEMPLATES_LIST_KIND, SERVER_ANNOUNCEMENT_KIND,
+    TOOLS_LIST_KIND,
 };
-use contextvm_sdk::core::types::EncryptionMode;
+use contextvm_sdk::core::types::{EncryptionMode, GiftWrapMode};
 use contextvm_sdk::relay::mock::MockRelayPool;
 use contextvm_sdk::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use contextvm_sdk::transport::server::{NostrServerTransport, NostrServerTransportConfig};
@@ -2330,7 +2332,7 @@ async fn announced_server_does_not_error_on_unauthorized_notification() {
     );
 }
 
-// ── 31. First response includes discovery tags ──────────────────────────────
+// ── 31. First response includes discovery tags (upstream CEP-19) ─────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn first_response_includes_discovery_tags() {
@@ -2346,7 +2348,7 @@ async fn first_response_includes_discovery_tags() {
                 ..Default::default()
             }),
             encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: contextvm_sdk::core::types::GiftWrapMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Optional,
             ..Default::default()
         },
         Arc::clone(&s_pool) as Arc<dyn RelayPoolTrait>,
@@ -2429,7 +2431,7 @@ async fn first_response_includes_discovery_tags() {
     let events = s_pool.stored_events().await;
     let responses: Vec<_> = events
         .iter()
-        .filter(|e| e.kind == Kind::Custom(contextvm_sdk::core::constants::CTXVM_MESSAGES_KIND))
+        .filter(|e| e.kind == Kind::Custom(CTXVM_MESSAGES_KIND))
         .cloned()
         .collect();
 
@@ -2472,7 +2474,7 @@ async fn notification_mirror_selection_wrt_cep_19() {
     let mut server = NostrServerTransport::with_relay_pool(
         NostrServerTransportConfig {
             encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: contextvm_sdk::core::types::GiftWrapMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Optional,
             ..Default::default()
         },
         Arc::clone(&s_pool) as Arc<dyn RelayPoolTrait>,
@@ -2484,7 +2486,7 @@ async fn notification_mirror_selection_wrt_cep_19() {
         NostrClientTransportConfig {
             server_pubkey: server_pubkey.to_hex(),
             encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: contextvm_sdk::core::types::GiftWrapMode::Ephemeral, // Forces client to use Ephemeral
+            gift_wrap_mode: GiftWrapMode::Ephemeral,
             ..Default::default()
         },
         as_pool(client_pool),
@@ -2500,7 +2502,6 @@ async fn notification_mirror_selection_wrt_cep_19() {
     client.start().await.expect("client start");
     let_event_loops_start().await;
 
-    // Send a request. It should be encrypted and wrapped with Ephemeral (21059)
     let request1 = JsonRpcMessage::Request(JsonRpcRequest {
         jsonrpc: "2.0".to_string(),
         id: serde_json::json!("req-1"),
@@ -2514,7 +2515,6 @@ async fn notification_mirror_selection_wrt_cep_19() {
         .expect("timeout")
         .expect("channel closed");
 
-    // Reply with a correlated notification
     let notification = JsonRpcMessage::Notification(JsonRpcNotification {
         jsonrpc: "2.0".to_string(),
         method: "notifications/progress".to_string(),
@@ -2529,19 +2529,339 @@ async fn notification_mirror_selection_wrt_cep_19() {
         .await
         .expect("send notification");
 
-    // The notification should have been sent as an Ephemeral Gift Wrap (21059)
     let events = s_pool.stored_events().await;
     let ephemeral_wraps: Vec<_> = events
         .iter()
-        .filter(|e| {
-            e.kind == Kind::Custom(contextvm_sdk::core::constants::EPHEMERAL_GIFT_WRAP_KIND)
-        })
+        .filter(|e| e.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND))
         .cloned()
         .collect();
 
-    // 1 from client (request), 1 from server (notification). The client also sends other msgs?
     assert!(
         ephemeral_wraps.len() >= 2,
         "Expected ephemeral wraps for both request and notification"
     );
+}
+
+// ── CEP-35: Server-side discovery tag emission & capability learning ─────────
+
+fn event_tag_vecs(event: &Event) -> Vec<Vec<String>> {
+    event.tags.iter().map(|t| t.clone().to_vec()).collect()
+}
+
+fn has_tag_name(event: &Event, name: &str) -> bool {
+    event_tag_vecs(event)
+        .iter()
+        .any(|v| v.first().map(|s| s.as_str()) == Some(name))
+}
+
+fn get_tag_value(event: &Event, name: &str) -> Option<String> {
+    event_tag_vecs(event).iter().find_map(|v| {
+        if v.first().map(|s| s.as_str()) == Some(name) {
+            v.get(1).cloned()
+        } else {
+            None
+        }
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_response_includes_encryption_tags_when_enabled() {
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+    let server_pool_arc = Arc::new(server_pool);
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Optional,
+            ..Default::default()
+        },
+        Arc::clone(&server_pool_arc) as Arc<dyn RelayPoolTrait>,
+    )
+    .await
+    .unwrap();
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .unwrap();
+
+    let mut server_rx = server.take_message_receiver().unwrap();
+    let mut client_rx = client.take_message_receiver().unwrap();
+    server.start().await.unwrap();
+    client.start().await.unwrap();
+    let_event_loops_start().await;
+
+    client
+        .send(&JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "initialize".to_string(),
+            params: None,
+        }))
+        .await
+        .unwrap();
+    let incoming = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    server
+        .send_response(
+            &incoming.event_id,
+            JsonRpcMessage::Response(JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!(1),
+                result: serde_json::json!({}),
+            }),
+        )
+        .await
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_millis(500), client_rx.recv())
+        .await
+        .unwrap();
+
+    let events = server_pool_arc.stored_events().await;
+    let response_event = events
+        .iter()
+        .find(|e| e.kind == Kind::Custom(CTXVM_MESSAGES_KIND) && has_tag_name(e, "e"))
+        .expect("response event must exist");
+
+    assert!(
+        has_tag_name(response_event, tags::SUPPORT_ENCRYPTION),
+        "first response must include support_encryption when mode != Disabled"
+    );
+    assert!(
+        has_tag_name(response_event, tags::SUPPORT_ENCRYPTION_EPHEMERAL),
+        "first response must include support_encryption_ephemeral when GiftWrapMode != Persistent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_response_excludes_ephemeral_tag_when_persistent() {
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+    let server_pool_arc = Arc::new(server_pool);
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Persistent,
+            ..Default::default()
+        },
+        Arc::clone(&server_pool_arc) as Arc<dyn RelayPoolTrait>,
+    )
+    .await
+    .unwrap();
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .unwrap();
+
+    let mut server_rx = server.take_message_receiver().unwrap();
+    let mut client_rx = client.take_message_receiver().unwrap();
+    server.start().await.unwrap();
+    client.start().await.unwrap();
+    let_event_loops_start().await;
+
+    client
+        .send(&JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "initialize".to_string(),
+            params: None,
+        }))
+        .await
+        .unwrap();
+    let incoming = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    server
+        .send_response(
+            &incoming.event_id,
+            JsonRpcMessage::Response(JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!(1),
+                result: serde_json::json!({}),
+            }),
+        )
+        .await
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_millis(500), client_rx.recv())
+        .await
+        .unwrap();
+
+    let events = server_pool_arc.stored_events().await;
+    let response_event = events
+        .iter()
+        .find(|e| e.kind == Kind::Custom(CTXVM_MESSAGES_KIND) && has_tag_name(e, "e"))
+        .unwrap();
+
+    assert!(
+        has_tag_name(response_event, tags::SUPPORT_ENCRYPTION),
+        "support_encryption must be present"
+    );
+    assert!(
+        !has_tag_name(response_event, tags::SUPPORT_ENCRYPTION_EPHEMERAL),
+        "support_encryption_ephemeral must NOT be present when GiftWrapMode is Persistent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_learns_capabilities_from_client_request() {
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(server_pool),
+    )
+    .await
+    .unwrap();
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .unwrap();
+
+    let mut server_rx = server.take_message_receiver().unwrap();
+    server.start().await.unwrap();
+    client.start().await.unwrap();
+    let_event_loops_start().await;
+
+    client
+        .send(&JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "initialize".to_string(),
+            params: None,
+        }))
+        .await
+        .unwrap();
+
+    let incoming = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(incoming.message.method(), Some("initialize"));
+    client
+        .send(&JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(2),
+            method: "tools/list".to_string(),
+            params: None,
+        }))
+        .await
+        .unwrap();
+    let incoming2 = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(incoming2.message.method(), Some("tools/list"));
+    assert_eq!(incoming.client_pubkey, incoming2.client_pubkey);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_disabled_encryption_omits_encryption_tags() {
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+    let server_pool_arc = Arc::new(server_pool);
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            server_info: Some(ServerInfo {
+                name: Some("NoEncrypt".to_string()),
+                ..Default::default()
+            }),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        Arc::clone(&server_pool_arc) as Arc<dyn RelayPoolTrait>,
+    )
+    .await
+    .unwrap();
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .unwrap();
+
+    let mut server_rx = server.take_message_receiver().unwrap();
+    let mut client_rx = client.take_message_receiver().unwrap();
+    server.start().await.unwrap();
+    client.start().await.unwrap();
+    let_event_loops_start().await;
+
+    client
+        .send(&JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "initialize".to_string(),
+            params: None,
+        }))
+        .await
+        .unwrap();
+    let incoming = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    server
+        .send_response(
+            &incoming.event_id,
+            JsonRpcMessage::Response(JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!(1),
+                result: serde_json::json!({}),
+            }),
+        )
+        .await
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_millis(500), client_rx.recv())
+        .await
+        .unwrap();
+
+    let events = server_pool_arc.stored_events().await;
+    let response_event = events
+        .iter()
+        .find(|e| e.kind == Kind::Custom(CTXVM_MESSAGES_KIND) && has_tag_name(e, "e"))
+        .unwrap();
+
+    assert!(has_tag_name(response_event, tags::NAME));
+    assert!(
+        !has_tag_name(response_event, tags::SUPPORT_ENCRYPTION),
+        "encryption tags must be omitted when EncryptionMode is Disabled"
+    );
+    assert!(!has_tag_name(
+        response_event,
+        tags::SUPPORT_ENCRYPTION_EPHEMERAL
+    ));
 }


### PR DESCRIPTION
Part of #43

Implements CEP-35 server-side capability exchange: the server now attaches its discovery tags on the first message to each client and learns client capabilities from inbound event tags.

Changes:

ClientSession gains four new fields (all false by default): has_sent_common_tags, supports_encryption, 
supports_ephemeral_encryption, supports_oversized_transfer.

BaseTransport gets a compose_outbound_tags() helper for canonical tag ordering: routing → discovery → negotiation.

Server sends its discovery tags (server info + capability tags) on the first response or notification to each client, then 
stops, one-shot per session.


Server event loop now calls learn_peer_capabilities() on every inbound inner event and OR-assigns the result to the client session. Capabilities can only be upgraded, never downgraded.

Tests:
- 6 session store unit tests for new capability fields
- 4 unit tests for compose_outbound_tags
- 3 unit tests for CEP-35 session behavior
- 5 integration tests covering first-response tag emission, encryption tag conditions, and capability learning

<img width="708" height="209" alt="Screenshot 2026-05-02 at 1 40 17 AM" src="https://github.com/user-attachments/assets/2d0715fc-baa5-4366-984f-e77160833e5f" />
