### PR TITLE
fix: remove single-peer barrier in RMCP worker and add LRU-bounded SessionStore

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -126,6 +126,7 @@ mod tests {
             is_announced_server: true,
             allowed_public_keys: vec!["abc123".to_string()],
             excluded_capabilities: vec![],
+            max_sessions: 1000,
             cleanup_interval: Duration::from_secs(120),
             session_timeout: Duration::from_secs(600),
             log_file_path: None,

--- a/src/relay/mock.rs
+++ b/src/relay/mock.rs
@@ -105,6 +105,24 @@ impl MockRelayPool {
         (a, b)
     }
 
+    /// Create `n` linked mock relay pools with different signing keys.
+    ///
+    /// All pools share the same event store and notification channel so events
+    /// published by any one pool are visible to all others' `notifications()`
+    /// receivers.  Useful for multi-client integration tests.
+    pub fn create_linked_group(n: usize) -> Vec<Self> {
+        assert!(n > 0, "group must have at least one pool");
+        let (tx, _rx) = tokio::sync::broadcast::channel(1024);
+        let inner = Arc::new(Mutex::new(MockRelayInner::new()));
+        (0..n)
+            .map(|_| Self {
+                inner: Arc::clone(&inner),
+                notification_tx: tx.clone(),
+                keys: Keys::generate(),
+            })
+            .collect()
+    }
+
     /// Clone of all events published so far (useful for assertions in tests).
     pub async fn stored_events(&self) -> Vec<Event> {
         self.inner.lock().await.events.clone()

--- a/src/rmcp_transport/pipeline_tests.rs
+++ b/src/rmcp_transport/pipeline_tests.rs
@@ -14,16 +14,13 @@
 
 #[cfg(all(test, feature = "rmcp"))]
 mod tests {
-    use std::collections::HashMap;
-
     use rmcp::model::{
         ClientJsonRpcMessage, ClientResult, RequestId, ServerJsonRpcMessage, ServerResult,
     };
 
     use crate::core::serializers;
     use crate::core::types::{
-        JsonRpcError, JsonRpcErrorResponse, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
-        JsonRpcResponse,
+        JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
     };
     use crate::rmcp_transport::convert::{
         internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
@@ -210,89 +207,120 @@ mod tests {
         assert_eq!(v["result"]["tools"], serde_json::json!([]));
     }
 
-    // ── Layer 5: ID correlation map logic (mirrors NostrServerWorker) ────────
+    // ── Layer 5: event_id-based request correlation (mirrors NostrServerWorker) ──
 
     #[test]
-    fn layer5_worker_correlation_map_number_id() {
-        let mut request_id_to_event_id: HashMap<String, String> = HashMap::new();
-        let fake_event_id = "aaaaaa".to_string();
-
-        // Step 1: incoming request arrives — worker stores req_id → event_id
-        let req = JsonRpcMessage::Request(JsonRpcRequest {
+    fn layer5_worker_uses_event_id_as_request_id() {
+        // Simulate the worker rewriting req.id to the Nostr event_id.
+        let event_id = "abc123def456";
+        let mut req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: serde_json::json!(42),
             method: "tools/list".to_string(),
             params: None,
-        });
+        };
 
-        if let JsonRpcMessage::Request(ref r) = req {
-            let key = serde_json::to_string(&r.id).unwrap();
-            request_id_to_event_id.insert(key, fake_event_id.clone());
+        // Worker inbound path: rewrite id to event_id
+        req.id = serde_json::json!(event_id);
+        assert_eq!(req.id, serde_json::json!("abc123def456"));
+
+        // Convert through rmcp bridge — ID must survive the roundtrip
+        let msg = JsonRpcMessage::Request(req);
+        let rmcp_rx = internal_to_rmcp_server_rx(&msg).unwrap();
+        let v = serde_json::to_value(&rmcp_rx).unwrap();
+        assert_eq!(v["id"], serde_json::json!("abc123def456"));
+
+        // Simulate rmcp handler echoing the event_id back in the response
+        let rmcp_tx = ServerJsonRpcMessage::response(
+            ServerResult::empty(()),
+            RequestId::String(std::sync::Arc::from(event_id)),
+        );
+        let response = rmcp_server_tx_to_internal(rmcp_tx).unwrap();
+
+        // The response ID is the event_id — worker passes it directly to send_response
+        match response {
+            JsonRpcMessage::Response(r) => {
+                assert_eq!(r.id.as_str(), Some(event_id));
+            }
+            other => panic!("expected Response, got {other:?}"),
         }
+    }
 
-        // Step 2: rmcp response comes back with id=42
-        let response = JsonRpcMessage::Response(JsonRpcResponse {
+    #[test]
+    fn layer5_worker_two_clients_no_collision() {
+        // Two clients both send requests with id: 1.  The worker rewrites each
+        // to its unique Nostr event_id, so no collision occurs.
+        let event_id_a = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111";
+        let event_id_b = "bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222";
+
+        let mut req_a = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
-            id: serde_json::json!(42),
-            result: serde_json::json!({}),
-        });
+            id: serde_json::json!(1),
+            method: "tools/list".to_string(),
+            params: None,
+        };
+        let mut req_b = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "tools/list".to_string(),
+            params: None,
+        };
 
-        // Step 3: worker looks up the event_id to call send_response
-        if let JsonRpcMessage::Response(ref r) = response {
-            let key = serde_json::to_string(&r.id).unwrap();
-            let found = request_id_to_event_id.remove(&key);
-            assert_eq!(found, Some(fake_event_id));
-        } else {
-            panic!("expected Response");
-        }
+        // Worker rewrites both to their respective event IDs
+        req_a.id = serde_json::json!(event_id_a);
+        req_b.id = serde_json::json!(event_id_b);
 
-        // Map should be empty after handling
-        assert!(request_id_to_event_id.is_empty());
+        // After rewrite, the IDs are distinct even though both clients sent id: 1
+        assert_ne!(req_a.id, req_b.id);
+        assert_eq!(req_a.id.as_str(), Some(event_id_a));
+        assert_eq!(req_b.id.as_str(), Some(event_id_b));
+
+        // Responses echo back the event_id — each routes to the correct client
+        let rmcp_resp_a = ServerJsonRpcMessage::response(
+            ServerResult::empty(()),
+            RequestId::String(std::sync::Arc::from(event_id_a)),
+        );
+        let rmcp_resp_b = ServerJsonRpcMessage::response(
+            ServerResult::empty(()),
+            RequestId::String(std::sync::Arc::from(event_id_b)),
+        );
+
+        let resp_a = rmcp_server_tx_to_internal(rmcp_resp_a).unwrap();
+        let resp_b = rmcp_server_tx_to_internal(rmcp_resp_b).unwrap();
+
+        // Each response carries its own event_id — no cross-wiring
+        assert_eq!(resp_a.id().unwrap().as_str(), Some(event_id_a));
+        assert_eq!(resp_b.id().unwrap().as_str(), Some(event_id_b));
     }
 
     #[test]
-    fn layer5_worker_correlation_map_string_id() {
-        let mut request_id_to_event_id: HashMap<String, String> = HashMap::new();
-        let fake_event_id = "bbbbbb".to_string();
-
-        // String IDs serialize with surrounding quotes: "\"req-abc\""
-        let req_id = serde_json::json!("req-abc");
-        let key = serde_json::to_string(&req_id).unwrap();
-        request_id_to_event_id.insert(key.clone(), fake_event_id.clone());
-
-        // The response ID serializes identically
-        let resp_id = serde_json::json!("req-abc");
-        let resp_key = serde_json::to_string(&resp_id).unwrap();
-
-        // Key derived from response ID must match the one stored from request ID
-        assert_eq!(key, resp_key);
-        assert_eq!(
-            request_id_to_event_id.remove(&resp_key),
-            Some(fake_event_id)
-        );
-    }
-
-    #[test]
-    fn layer5_error_response_correlation_works() {
-        let mut map: HashMap<String, String> = HashMap::new();
-        map.insert(
-            serde_json::to_string(&serde_json::json!(5)).unwrap(),
-            "evt5".to_string(),
-        );
-
-        let error_response = JsonRpcMessage::ErrorResponse(JsonRpcErrorResponse {
+    fn layer5_error_response_carries_event_id() {
+        // Error responses also carry the event_id for routing.
+        let event_id = "deadbeef";
+        let mut req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: serde_json::json!(5),
-            error: JsonRpcError {
-                code: -32601,
-                message: "Method not found".to_string(),
+            method: "tools/call".to_string(),
+            params: None,
+        };
+        req.id = serde_json::json!(event_id);
+
+        // rmcp handler returns an error with the rewritten event_id
+        let rmcp_err = ServerJsonRpcMessage::error(
+            rmcp::model::ErrorData {
+                code: rmcp::model::ErrorCode::METHOD_NOT_FOUND,
+                message: "Method not found".into(),
                 data: None,
             },
-        });
+            RequestId::String(std::sync::Arc::from(event_id)),
+        );
+        let internal = rmcp_server_tx_to_internal(rmcp_err).unwrap();
 
-        if let JsonRpcMessage::ErrorResponse(ref r) = error_response {
-            let key = serde_json::to_string(&r.id).unwrap();
-            assert_eq!(map.remove(&key), Some("evt5".to_string()));
+        match internal {
+            JsonRpcMessage::ErrorResponse(r) => {
+                assert_eq!(r.id.as_str(), Some(event_id));
+            }
+            other => panic!("expected ErrorResponse, got {other:?}"),
         }
     }
 

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -3,8 +3,6 @@
 //! This file defines wrapper types that bind existing ContextVM Nostr
 //! transports to rmcp's worker abstraction.
 
-use std::collections::HashMap;
-
 use crate::core::error::Result;
 use crate::core::types::JsonRpcMessage;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
@@ -19,12 +17,16 @@ use super::convert::{
 const LOG_TARGET: &str = "contextvm_sdk::rmcp_transport::worker";
 
 /// rmcp server worker wrapper for ContextVM Nostr server transport.
+///
+/// Multiplexes all connected clients through a single rmcp service instance.
+/// Inbound requests have their JSON-RPC `id` rewritten to the Nostr `event_id`
+/// before being forwarded to the rmcp handler.  Since event IDs are globally
+/// unique (SHA-256 hashes), this eliminates collisions when different clients
+/// use the same JSON-RPC request IDs.  The transport's event-route store
+/// handles response routing back to the originating client; server-initiated
+/// notifications are broadcast to all initialized clients.
 pub struct NostrServerWorker {
     transport: NostrServerTransport,
-    // rmcp service instance is single-peer. Keep one active client per worker.
-    active_client_pubkey: Option<String>,
-    // Maps request id (serialized JSON value) -> incoming Nostr event id.
-    request_id_to_event_id: HashMap<String, String>,
 }
 
 impl NostrServerWorker {
@@ -34,11 +36,7 @@ impl NostrServerWorker {
         T: nostr_sdk::prelude::IntoNostrSigner,
     {
         let transport = NostrServerTransport::new(signer, config).await?;
-        Ok(Self {
-            transport,
-            active_client_pubkey: None,
-            request_id_to_event_id: HashMap::new(),
-        })
+        Ok(Self { transport })
     }
 
     /// Access the wrapped transport.
@@ -88,46 +86,18 @@ impl Worker for NostrServerWorker {
                     };
 
                     let crate::transport::server::IncomingRequest {
-                        message,
-                        client_pubkey,
+                        mut message,
                         event_id,
                         ..
                     } = incoming;
 
-                    match &self.active_client_pubkey {
-                        Some(active) if active != &client_pubkey => {
-                            tracing::warn!(
-                                target: LOG_TARGET,
-                                active_client = %active,
-                                ignored_client = %client_pubkey,
-                                "Ignoring message from second client: rmcp server worker currently supports one active client per worker"
-                            );
-                            continue;
-                        }
-                        None => {
-                            tracing::info!(
-                                target: LOG_TARGET,
-                                client_pubkey = %client_pubkey,
-                                "Binding rmcp server worker to first client session"
-                            );
-                            self.active_client_pubkey = Some(client_pubkey.clone());
-                        }
-                        _ => {}
-                    }
-
-                    if let JsonRpcMessage::Request(req) = &message {
-                        match serde_json::to_string(&req.id) {
-                            Ok(request_key) => {
-                                self.request_id_to_event_id.insert(request_key, event_id);
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: LOG_TARGET,
-                                    error = %e,
-                                    "Failed to serialize request id for correlation map"
-                                );
-                            }
-                        }
+                    // Rewrite the JSON-RPC request ID to the Nostr event_id.
+                    // Event IDs are globally unique (SHA-256), so no collision
+                    // across clients.  The transport's event-route store maps
+                    // event_id → (client_pubkey, original_request_id) and
+                    // restores the original ID in `send_response`.
+                    if let JsonRpcMessage::Request(ref mut req) = message {
+                        req.id = serde_json::json!(event_id);
                     }
 
                     if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&message) {
@@ -276,76 +246,44 @@ impl Worker for NostrClientWorker {
 }
 
 impl NostrServerWorker {
+    /// Forward an outbound message from the rmcp handler to the Nostr transport.
+    ///
+    /// Response IDs carry the Nostr event_id set during ingest.  The transport's
+    /// `send_response` uses this to look up the route (client_pubkey +
+    /// original_request_id) and deliver the response to the correct client.
+    /// Notifications and server-initiated requests are broadcast to all
+    /// initialized clients.
     async fn forward_server_internal(&mut self, message: JsonRpcMessage) -> Result<()> {
         match message {
             JsonRpcMessage::Response(resp) => {
-                let request_key = serde_json::to_string(&resp.id).map_err(|e| {
-                    crate::core::error::Error::Validation(format!(
-                        "failed to serialize rmcp response id for correlation lookup: {e}"
-                    ))
+                let event_id = resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+                    crate::core::error::Error::Validation(
+                        "rmcp server response id is not a string event_id".to_string(),
+                    )
                 })?;
-
-                let event_id =
-                    if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
-                        event_id
-                    } else {
-                        resp.id.as_str().map(str::to_owned).ok_or_else(|| {
-                            crate::core::error::Error::Validation(
-							"rmcp server response id has no known correlation mapping and is not a string event id"
-								.to_string(),
-						)
-                        })?
-                    };
 
                 self.transport
                     .send_response(&event_id, JsonRpcMessage::Response(resp))
                     .await
             }
             JsonRpcMessage::ErrorResponse(resp) => {
-                let request_key = serde_json::to_string(&resp.id).map_err(|e| {
-                    crate::core::error::Error::Validation(format!(
-                        "failed to serialize rmcp error response id for correlation lookup: {e}"
-                    ))
+                let event_id = resp.id.as_str().map(str::to_owned).ok_or_else(|| {
+                    crate::core::error::Error::Validation(
+                        "rmcp server error response id is not a string event_id".to_string(),
+                    )
                 })?;
-
-                let event_id =
-                    if let Some(event_id) = self.request_id_to_event_id.remove(&request_key) {
-                        event_id
-                    } else {
-                        resp.id.as_str().map(str::to_owned).ok_or_else(|| {
-                            crate::core::error::Error::Validation(
-							"rmcp server error response id has no known correlation mapping and is not a string event id"
-								.to_string(),
-						)
-                        })?
-                    };
 
                 self.transport
                     .send_response(&event_id, JsonRpcMessage::ErrorResponse(resp))
                     .await
             }
             JsonRpcMessage::Notification(notification) => {
-                let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
-                    crate::core::error::Error::Validation(
-                        "cannot forward rmcp server notification: no active client bound"
-                            .to_string(),
-                    )
-                })?;
                 let message = JsonRpcMessage::Notification(notification);
-                self.transport
-                    .send_notification(target, &message, None)
-                    .await
+                self.transport.broadcast_notification(&message).await
             }
             JsonRpcMessage::Request(request) => {
-                let target = self.active_client_pubkey.as_deref().ok_or_else(|| {
-                    crate::core::error::Error::Validation(
-                        "cannot forward rmcp server request: no active client bound".to_string(),
-                    )
-                })?;
                 let message = JsonRpcMessage::Request(request);
-                self.transport
-                    .send_notification(target, &message, None)
-                    .await
+                self.transport.broadcast_notification(&message).await
             }
         }
     }

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -48,6 +48,8 @@ pub struct NostrServerTransportConfig {
     pub allowed_public_keys: Vec<String>,
     /// Capabilities excluded from pubkey whitelisting.
     pub excluded_capabilities: Vec<CapabilityExclusion>,
+    /// Maximum number of concurrent client sessions (LRU-bounded, default: 1000).
+    pub max_sessions: usize,
     /// Session cleanup interval (default: 60s).
     pub cleanup_interval: Duration,
     /// Session timeout (default: 300s).
@@ -66,6 +68,7 @@ impl Default for NostrServerTransportConfig {
             is_announced_server: false,
             allowed_public_keys: Vec::new(),
             excluded_capabilities: Vec::new(),
+            max_sessions: session_store::DEFAULT_MAX_SESSIONS,
             cleanup_interval: Duration::from_secs(60),
             session_timeout: Duration::from_secs(300),
             log_file_path: None,
@@ -147,10 +150,10 @@ impl NostrServerTransport {
                 encryption_mode: config.encryption_mode,
                 is_connected: false,
             },
+            sessions: SessionStore::with_capacity(config.max_sessions),
             config,
             extra_common_tags: Vec::new(),
             pricing_tags: Vec::new(),
-            sessions: SessionStore::new(),
             event_routes: ServerEventRouteStore::new(),
             request_wrap_kinds: Arc::new(RwLock::new(HashMap::new())),
             seen_gift_wrap_ids,
@@ -184,10 +187,10 @@ impl NostrServerTransport {
                 encryption_mode: config.encryption_mode,
                 is_connected: false,
             },
+            sessions: SessionStore::with_capacity(config.max_sessions),
             config,
             extra_common_tags: Vec::new(),
             pricing_tags: Vec::new(),
-            sessions: SessionStore::new(),
             request_wrap_kinds: Arc::new(RwLock::new(HashMap::new())),
             event_routes: ServerEventRouteStore::new(),
             seen_gift_wrap_ids,
@@ -1054,10 +1057,21 @@ impl NostrServerTransport {
                 }
 
                 // Session management
+                let on_evicted_cb = sessions.eviction_callback();
                 let mut sessions_w = sessions.write().await;
-                let session = sessions_w
-                    .entry(sender_pubkey.clone())
-                    .or_insert_with(|| ClientSession::new(is_encrypted));
+                if !sessions_w.contains(&sender_pubkey) {
+                    let evicted =
+                        sessions_w.push(sender_pubkey.clone(), ClientSession::new(is_encrypted));
+                    SessionStore::handle_eviction(
+                        &sender_pubkey,
+                        evicted,
+                        &mut sessions_w,
+                        on_evicted_cb.as_ref(),
+                        &event_routes,
+                    )
+                    .await;
+                }
+                let session = sessions_w.get_mut(&sender_pubkey).unwrap();
                 session.update_activity();
                 session.is_encrypted = is_encrypted;
 
@@ -1156,21 +1170,25 @@ impl NostrServerTransport {
         let mut cleaned = 0;
         let mut stale_event_ids = Vec::new();
 
-        sessions_w.retain(|pubkey, session| {
-            if session.last_activity.elapsed() > timeout {
+        // LruCache has no retain(); collect expired keys then pop each one.
+        let expired_keys: Vec<String> = sessions_w
+            .iter()
+            .filter(|(_, session)| session.last_activity.elapsed() > timeout)
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        for key in &expired_keys {
+            if let Some(session) = sessions_w.pop(key) {
                 stale_event_ids.extend(session.pending_requests.keys().cloned());
                 stale_event_ids.extend(session.event_to_progress_token.keys().cloned());
                 tracing::debug!(
                     target: LOG_TARGET,
-                    client_pubkey = %pubkey,
+                    client_pubkey = %key,
                     "Session expired"
                 );
                 cleaned += 1;
-                false
-            } else {
-                true
             }
-        });
+        }
         drop(sessions_w);
 
         {
@@ -1306,10 +1324,7 @@ mod tests {
         session
             .pending_requests
             .insert("evt1".to_string(), serde_json::json!(1));
-        sessions
-            .write()
-            .await
-            .insert("pubkey1".to_string(), session);
+        sessions.write().await.put("pubkey1".to_string(), session);
         event_routes
             .register(
                 "evt1".to_string(),
@@ -1352,7 +1367,9 @@ mod tests {
         let event_routes = ServerEventRouteStore::new();
         let request_wrap_kinds = Arc::new(RwLock::new(HashMap::new()));
 
-        sessions.get_or_create_session("active", false).await;
+        sessions
+            .get_or_create_session("active", false, &event_routes)
+            .await;
 
         let cleaned = NostrServerTransport::cleanup_sessions(
             &sessions,
@@ -1501,6 +1518,7 @@ mod tests {
         assert_eq!(config.gift_wrap_mode, GiftWrapMode::Optional);
         assert!(config.allowed_public_keys.is_empty());
         assert!(config.excluded_capabilities.is_empty());
+        assert_eq!(config.max_sessions, 1000);
         assert_eq!(config.cleanup_interval, Duration::from_secs(60));
         assert_eq!(config.session_timeout, Duration::from_secs(300));
         assert!(config.server_info.is_none());

--- a/src/transport/server/session_store.rs
+++ b/src/transport/server/session_store.rs
@@ -1,16 +1,40 @@
 //! Server-side session store for managing client sessions.
+//!
+//! Uses an LRU cache bounded by `max_sessions` (default 1000, matching the TS SDK
+//! server session store).  When a new session would exceed capacity the
+//! least-recently-used session is evicted.  If the evicted session still has
+//! active routes in the correlation store it is recreated with clean state
+//! (eviction safety, matching TS SDK's `hasActiveRoutesForClient` check), and
+//! the optional eviction callback fires so external code can clean up resources.
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use lru::LruCache;
 use tokio::sync::RwLock;
 
 use crate::core::types::ClientSession;
+use crate::transport::server::ServerEventRouteStore;
+
+const LOG_TARGET: &str = "contextvm_sdk::transport::server::session_store";
+
+/// Default maximum number of concurrent client sessions.
+///
+/// Matches the TS SDK's `SessionStore` default (`maxSessions ?? 1000`), not
+/// the broader `DEFAULT_LRU_SIZE` constant (5000) used elsewhere in the TS SDK.
+pub const DEFAULT_MAX_SESSIONS: usize = 1000;
+
+/// Callback invoked when a session is evicted from the LRU cache.
+/// Receives the evicted client's public key (hex).
+pub type EvictionCallback = Arc<dyn Fn(String) + Send + Sync>;
 
 /// Manages client sessions keyed by public key (hex).
+///
+/// Backed by an LRU cache so memory usage is bounded.
 #[derive(Clone)]
 pub struct SessionStore {
-    sessions: Arc<RwLock<HashMap<String, ClientSession>>>,
+    sessions: Arc<RwLock<LruCache<String, ClientSession>>>,
+    on_evicted: Option<EvictionCallback>,
 }
 
 impl Default for SessionStore {
@@ -20,20 +44,58 @@ impl Default for SessionStore {
 }
 
 impl SessionStore {
+    /// Create a store with the default capacity ([`DEFAULT_MAX_SESSIONS`]).
     pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MAX_SESSIONS)
+    }
+
+    /// Create a store with a specific maximum number of sessions.
+    pub fn with_capacity(max_sessions: usize) -> Self {
         Self {
-            sessions: Arc::new(RwLock::new(HashMap::new())),
+            sessions: Arc::new(RwLock::new(LruCache::new(
+                NonZeroUsize::new(max_sessions).expect("max_sessions must be > 0"),
+            ))),
+            on_evicted: None,
         }
     }
 
+    /// Register a callback that fires when a session is evicted from the LRU.
+    pub fn set_eviction_callback(&mut self, cb: EvictionCallback) {
+        self.on_evicted = Some(cb);
+    }
+
+    /// Clone the eviction callback (cheap Arc clone) for use outside the lock.
+    pub fn eviction_callback(&self) -> Option<EvictionCallback> {
+        self.on_evicted.clone()
+    }
+
     /// Get an existing session or create a new one. Returns `true` if a new session was created.
-    pub async fn get_or_create_session(&self, client_pubkey: &str, is_encrypted: bool) -> bool {
+    ///
+    /// `event_routes` is consulted during eviction safety: if the evicted client
+    /// still has active routes, the session is recreated with clean state
+    /// (matching TS SDK's `hasActiveRoutesForClient` check).
+    pub async fn get_or_create_session(
+        &self,
+        client_pubkey: &str,
+        is_encrypted: bool,
+        event_routes: &ServerEventRouteStore,
+    ) -> bool {
+        let on_evicted = self.on_evicted.clone();
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(client_pubkey) {
             session.is_encrypted = is_encrypted;
             false
         } else {
-            sessions.insert(client_pubkey.to_string(), ClientSession::new(is_encrypted));
+            let new_session = ClientSession::new(is_encrypted);
+            let evicted = sessions.push(client_pubkey.to_string(), new_session);
+            Self::handle_eviction(
+                client_pubkey,
+                evicted,
+                &mut sessions,
+                on_evicted.as_ref(),
+                event_routes,
+            )
+            .await;
             true
         }
     }
@@ -42,7 +104,7 @@ impl SessionStore {
     /// Returns `None` if the session does not exist.
     pub async fn get_session(&self, client_pubkey: &str) -> Option<SessionSnapshot> {
         let sessions = self.sessions.read().await;
-        sessions.get(client_pubkey).map(|s| SessionSnapshot {
+        sessions.peek(client_pubkey).map(|s| SessionSnapshot {
             is_initialized: s.is_initialized,
             is_encrypted: s.is_encrypted,
             has_sent_common_tags: s.has_sent_common_tags,
@@ -74,7 +136,7 @@ impl SessionStore {
 
     /// Remove a session. Returns `true` if it existed.
     pub async fn remove_session(&self, client_pubkey: &str) -> bool {
-        self.sessions.write().await.remove(client_pubkey).is_some()
+        self.sessions.write().await.pop(client_pubkey).is_some()
     }
 
     /// Remove all sessions.
@@ -106,18 +168,58 @@ impl SessionStore {
             .collect()
     }
 
-    /// Acquire write access to the underlying map (transport internals only).
+    /// Acquire write access to the underlying LRU cache (transport internals only).
     pub(crate) async fn write(
         &self,
-    ) -> tokio::sync::RwLockWriteGuard<'_, HashMap<String, ClientSession>> {
+    ) -> tokio::sync::RwLockWriteGuard<'_, LruCache<String, ClientSession>> {
         self.sessions.write().await
     }
 
-    /// Acquire read access to the underlying map (transport internals only).
+    /// Acquire read access to the underlying LRU cache (transport internals only).
     pub(crate) async fn read(
         &self,
-    ) -> tokio::sync::RwLockReadGuard<'_, HashMap<String, ClientSession>> {
+    ) -> tokio::sync::RwLockReadGuard<'_, LruCache<String, ClientSession>> {
         self.sessions.read().await
+    }
+
+    /// Handle a potential LRU eviction after inserting a session.
+    ///
+    /// If the evicted client still has active routes in the correlation store,
+    /// a clean session is re-inserted (eviction safety, matching TS SDK's
+    /// `hasActiveRoutesForClient` check).  The eviction callback fires only
+    /// for genuine, non-vetoed evictions.
+    pub(crate) async fn handle_eviction(
+        inserted_key: &str,
+        evicted: Option<(String, ClientSession)>,
+        sessions: &mut LruCache<String, ClientSession>,
+        on_evicted: Option<&EvictionCallback>,
+        event_routes: &ServerEventRouteStore,
+    ) {
+        if let Some((evicted_key, evicted_session)) = evicted {
+            // `push` also returns the old value when the *same* key is updated;
+            // only act when a *different* key was evicted due to capacity.
+            if evicted_key != inserted_key {
+                if event_routes
+                    .has_active_routes_for_client(&evicted_key)
+                    .await
+                {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        client_pubkey = %evicted_key,
+                        "LRU eviction of session with active routes; recreating with clean state"
+                    );
+                    // Re-insert with clean state so the client isn't orphaned.
+                    // Skip the external callback — the session still exists
+                    // (matches TS SDK: vetoed evictions don't fire the callback).
+                    let _ = sessions.push(
+                        evicted_key.clone(),
+                        ClientSession::new(evicted_session.is_encrypted),
+                    );
+                } else if let Some(cb) = on_evicted {
+                    cb(evicted_key);
+                }
+            }
+        }
     }
 }
 
@@ -134,12 +236,18 @@ pub struct SessionSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    fn routes() -> ServerEventRouteStore {
+        ServerEventRouteStore::new()
+    }
 
     #[tokio::test]
     async fn create_and_retrieve_session() {
         let store = SessionStore::new();
+        let r = routes();
 
-        let created = store.get_or_create_session("client-1", true).await;
+        let created = store.get_or_create_session("client-1", true, &r).await;
         assert!(created);
 
         let snap = store.get_session("client-1").await.unwrap();
@@ -150,14 +258,14 @@ mod tests {
     #[tokio::test]
     async fn get_or_create_returns_existing() {
         let store = SessionStore::new();
+        let r = routes();
 
-        let created = store.get_or_create_session("client-1", false).await;
+        let created = store.get_or_create_session("client-1", false, &r).await;
         assert!(created);
 
-        let created2 = store.get_or_create_session("client-1", true).await;
+        let created2 = store.get_or_create_session("client-1", true, &r).await;
         assert!(!created2);
 
-        // is_encrypted should have been updated.
         let snap = store.get_session("client-1").await.unwrap();
         assert!(snap.is_encrypted);
     }
@@ -165,7 +273,8 @@ mod tests {
     #[tokio::test]
     async fn mark_initialized() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
         assert!(store.mark_initialized("client-1").await);
         let snap = store.get_session("client-1").await.unwrap();
@@ -181,7 +290,8 @@ mod tests {
     #[tokio::test]
     async fn remove_session() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
         assert!(store.remove_session("client-1").await);
         assert!(store.get_session("client-1").await.is_none());
     }
@@ -195,8 +305,9 @@ mod tests {
     #[tokio::test]
     async fn clear_all_sessions() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
-        store.get_or_create_session("client-2", true).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
+        store.get_or_create_session("client-2", true, &r).await;
 
         store.clear().await;
 
@@ -208,8 +319,9 @@ mod tests {
     #[tokio::test]
     async fn get_all_sessions() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
-        store.get_or_create_session("client-2", true).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
+        store.get_or_create_session("client-2", true, &r).await;
 
         let all = store.get_all_sessions().await;
         assert_eq!(all.len(), 2);
@@ -224,10 +336,11 @@ mod tests {
     #[tokio::test]
     async fn new_session_capability_fields_default_false() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
         let sessions = store.read().await;
-        let session = sessions.get("client-1").unwrap();
+        let session = sessions.peek("client-1").unwrap();
         assert!(!session.has_sent_common_tags);
         assert!(!session.supports_encryption);
         assert!(!session.supports_ephemeral_encryption);
@@ -237,7 +350,8 @@ mod tests {
     #[tokio::test]
     async fn has_sent_common_tags_flag() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
         let mut sessions = store.write().await;
         let session = sessions.get_mut("client-1").unwrap();
@@ -249,9 +363,9 @@ mod tests {
     #[tokio::test]
     async fn capability_or_assign_persists() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
-        // First update: learn encryption support
         {
             let mut sessions = store.write().await;
             let session = sessions.get_mut("client-1").unwrap();
@@ -259,16 +373,15 @@ mod tests {
             session.supports_ephemeral_encryption |= false;
         }
 
-        // Second update: learn ephemeral support; encryption stays true
         {
             let mut sessions = store.write().await;
             let session = sessions.get_mut("client-1").unwrap();
-            session.supports_encryption |= false; // should stay true
+            session.supports_encryption |= false;
             session.supports_ephemeral_encryption |= true;
         }
 
         let sessions = store.read().await;
-        let session = sessions.get("client-1").unwrap();
+        let session = sessions.peek("client-1").unwrap();
         assert!(session.supports_encryption, "OR-assign must not downgrade");
         assert!(session.supports_ephemeral_encryption);
         assert!(!session.supports_oversized_transfer);
@@ -277,8 +390,9 @@ mod tests {
     #[tokio::test]
     async fn capability_fields_independent_per_client() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-a", false).await;
-        store.get_or_create_session("client-b", false).await;
+        let r = routes();
+        store.get_or_create_session("client-a", false, &r).await;
+        store.get_or_create_session("client-b", false, &r).await;
 
         {
             let mut sessions = store.write().await;
@@ -288,8 +402,8 @@ mod tests {
         }
 
         let sessions = store.read().await;
-        let sa = sessions.get("client-a").unwrap();
-        let sb = sessions.get("client-b").unwrap();
+        let sa = sessions.peek("client-a").unwrap();
+        let sb = sessions.peek("client-b").unwrap();
         assert!(sa.supports_encryption);
         assert!(sa.has_sent_common_tags);
         assert!(!sb.supports_encryption);
@@ -299,9 +413,9 @@ mod tests {
     #[tokio::test]
     async fn get_or_create_preserves_capability_fields() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
-        // Set capability fields
         {
             let mut sessions = store.write().await;
             let session = sessions.get_mut("client-1").unwrap();
@@ -309,13 +423,11 @@ mod tests {
             session.has_sent_common_tags = true;
         }
 
-        // Re-enter via get_or_create (existing session)
-        let created = store.get_or_create_session("client-1", true).await;
+        let created = store.get_or_create_session("client-1", true, &r).await;
         assert!(!created);
 
-        // Capability fields must survive
         let sessions = store.read().await;
-        let session = sessions.get("client-1").unwrap();
+        let session = sessions.peek("client-1").unwrap();
         assert!(session.supports_encryption);
         assert!(session.has_sent_common_tags);
     }
@@ -323,7 +435,8 @@ mod tests {
     #[tokio::test]
     async fn clear_resets_capability_fields() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
         {
             let mut sessions = store.write().await;
             let s = sessions.get_mut("client-1").unwrap();
@@ -331,11 +444,91 @@ mod tests {
         }
 
         store.clear().await;
-        store.get_or_create_session("client-1", false).await;
+        store.get_or_create_session("client-1", false, &r).await;
 
         let sessions = store.read().await;
-        let session = sessions.get("client-1").unwrap();
+        let session = sessions.peek("client-1").unwrap();
         assert!(!session.supports_encryption);
         assert!(!session.has_sent_common_tags);
+    }
+
+    // ── LRU eviction ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn lru_eviction_drops_oldest_session() {
+        let store = SessionStore::with_capacity(3);
+        let r = routes();
+        store.get_or_create_session("a", false, &r).await;
+        store.get_or_create_session("b", false, &r).await;
+        store.get_or_create_session("c", false, &r).await;
+
+        store.get_or_create_session("d", false, &r).await;
+
+        assert!(
+            store.get_session("a").await.is_none(),
+            "a should be evicted"
+        );
+        assert!(store.get_session("b").await.is_some());
+        assert!(store.get_session("c").await.is_some());
+        assert!(store.get_session("d").await.is_some());
+        assert_eq!(store.session_count().await, 3);
+    }
+
+    #[tokio::test]
+    async fn eviction_callback_fires_on_lru_eviction() {
+        let evicted = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let evicted_clone = evicted.clone();
+        let r = routes();
+
+        let mut store = SessionStore::with_capacity(2);
+        store.set_eviction_callback(Arc::new(move |pubkey| {
+            evicted_clone.lock().unwrap().push(pubkey);
+        }));
+
+        store.get_or_create_session("a", false, &r).await;
+        store.get_or_create_session("b", false, &r).await;
+        store.get_or_create_session("c", false, &r).await;
+
+        let evicted = evicted.lock().unwrap();
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0], "a");
+    }
+
+    #[tokio::test]
+    async fn eviction_safety_recreates_session_with_active_routes() {
+        let store = SessionStore::with_capacity(2);
+        let r = routes();
+        store.get_or_create_session("a", true, &r).await;
+        store.get_or_create_session("b", false, &r).await;
+
+        // Register an active route for client "a" in the correlation store
+        r.register("evt1".into(), "a".into(), json!(1), None).await;
+
+        // Adding "c" would normally evict "a", but eviction safety recreates it
+        // because "a" has active routes.
+        store.get_or_create_session("c", false, &r).await;
+
+        let snap = store.get_session("a").await;
+        assert!(
+            snap.is_some(),
+            "session with active routes must survive eviction"
+        );
+        // "b" was evicted instead (next LRU after "a" was re-inserted)
+        assert!(
+            store.get_session("b").await.is_none(),
+            "b should be evicted"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_capacity_sets_limit() {
+        let store = SessionStore::with_capacity(5);
+        let r = routes();
+        for i in 0..10 {
+            store
+                .get_or_create_session(&format!("client-{i}"), false, &r)
+                .await;
+        }
+        assert_eq!(store.session_count().await, 5);
     }
 }

--- a/tests/conformance_stores.rs
+++ b/tests/conformance_stores.rs
@@ -138,11 +138,16 @@ mod client_correlation_store {
 mod server_session_store {
     use super::*;
 
+    fn routes() -> ServerEventRouteStore {
+        ServerEventRouteStore::new()
+    }
+
     #[tokio::test]
     async fn create_and_retrieve_sessions() {
         let store = SessionStore::new();
+        let r = routes();
 
-        let created = store.get_or_create_session("client-1", true).await;
+        let created = store.get_or_create_session("client-1", true, &r).await;
         assert!(created);
 
         let session = store.get_session("client-1").await.unwrap();
@@ -156,7 +161,8 @@ mod server_session_store {
     #[tokio::test]
     async fn mark_sessions_as_initialized() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
         let result = store.mark_initialized("client-1").await;
         assert!(result);
@@ -168,7 +174,8 @@ mod server_session_store {
     #[tokio::test]
     async fn remove_sessions() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
 
         let result = store.remove_session("client-1").await;
         assert!(result);
@@ -178,8 +185,9 @@ mod server_session_store {
     #[tokio::test]
     async fn clear_all_sessions() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
-        store.get_or_create_session("client-2", true).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
+        store.get_or_create_session("client-2", true, &r).await;
 
         store.clear().await;
 
@@ -191,8 +199,9 @@ mod server_session_store {
     #[tokio::test]
     async fn iterate_over_all_sessions() {
         let store = SessionStore::new();
-        store.get_or_create_session("client-1", false).await;
-        store.get_or_create_session("client-2", true).await;
+        let r = routes();
+        store.get_or_create_session("client-1", false, &r).await;
+        store.get_or_create_session("client-2", true, &r).await;
 
         let sessions = store.get_all_sessions().await;
         assert_eq!(sessions.len(), 2);

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -3348,3 +3348,178 @@ async fn client_optional_encryption_emits_discovery_tags() {
         "inner event must carry support_encryption_ephemeral tag (Optional gift-wrap mode)"
     );
 }
+// ── Multi-client support ─────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multi_client_concurrent_requests_both_get_responses() {
+    // Two different clients send requests to the same server; both must get
+    // their own response (the single-peer barrier is removed).
+    let mut pools = MockRelayPool::create_linked_group(3);
+    let server_pool = pools.remove(0);
+    let client_b_pool = pools.remove(1);
+    let client_a_pool = pools.remove(0);
+    let server_pubkey = server_pool.mock_public_key();
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(server_pool),
+    )
+    .await
+    .expect("create server transport");
+
+    let mut client_a = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_a_pool),
+    )
+    .await
+    .expect("create client A");
+
+    let mut client_b = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_b_pool),
+    )
+    .await
+    .expect("create client B");
+
+    let mut server_rx = server
+        .take_message_receiver()
+        .expect("server message receiver");
+    let mut client_a_rx = client_a
+        .take_message_receiver()
+        .expect("client A message receiver");
+    let mut client_b_rx = client_b
+        .take_message_receiver()
+        .expect("client B message receiver");
+
+    server.start().await.expect("server start");
+    client_a.start().await.expect("client A start");
+    client_b.start().await.expect("client B start");
+    let_event_loops_start().await;
+
+    // Client A sends a request.
+    let req_a = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(1),
+        method: "tools/list".to_string(),
+        params: None,
+    });
+    client_a.send(&req_a).await.expect("client A send");
+
+    // Client B sends a request.
+    let req_b = JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(2),
+        method: "tools/list".to_string(),
+        params: None,
+    });
+    client_b.send(&req_b).await.expect("client B send");
+
+    // Server receives both requests (order may vary).
+    let incoming_1 = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .expect("timeout rx 1")
+        .expect("rx closed 1");
+    let incoming_2 = tokio::time::timeout(Duration::from_millis(500), server_rx.recv())
+        .await
+        .expect("timeout rx 2")
+        .expect("rx closed 2");
+
+    // Send responses to both.
+    let resp_1 = JsonRpcMessage::Response(JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: incoming_1.message.id().unwrap().clone(),
+        result: serde_json::json!({"tools": []}),
+    });
+    server
+        .send_response(&incoming_1.event_id, resp_1)
+        .await
+        .expect("server respond to 1");
+
+    let resp_2 = JsonRpcMessage::Response(JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        id: incoming_2.message.id().unwrap().clone(),
+        result: serde_json::json!({"tools": []}),
+    });
+    server
+        .send_response(&incoming_2.event_id, resp_2)
+        .await
+        .expect("server respond to 2");
+
+    // Both clients must receive their respective response.
+    let resp_a = tokio::time::timeout(Duration::from_millis(500), client_a_rx.recv())
+        .await
+        .expect("timeout client A response")
+        .expect("client A channel closed");
+    let resp_b = tokio::time::timeout(Duration::from_millis(500), client_b_rx.recv())
+        .await
+        .expect("timeout client B response")
+        .expect("client B channel closed");
+
+    assert!(
+        matches!(resp_a, JsonRpcMessage::Response(_)),
+        "client A must receive a response"
+    );
+    assert!(
+        matches!(resp_b, JsonRpcMessage::Response(_)),
+        "client B must receive a response"
+    );
+}
+
+// ── Session store LRU tests ─────────────────────────────────────────────────
+
+use contextvm_sdk::transport::server::SessionStore;
+use contextvm_sdk::ServerEventRouteStore;
+
+#[tokio::test]
+async fn session_store_lru_eviction() {
+    let store = SessionStore::with_capacity(3);
+    let r = ServerEventRouteStore::new();
+    store.get_or_create_session("a", false, &r).await;
+    store.get_or_create_session("b", false, &r).await;
+    store.get_or_create_session("c", false, &r).await;
+
+    // 4th session evicts the oldest ("a")
+    store.get_or_create_session("d", false, &r).await;
+
+    assert!(
+        store.get_session("a").await.is_none(),
+        "oldest session must be evicted when capacity is exceeded"
+    );
+    assert!(store.get_session("b").await.is_some());
+    assert!(store.get_session("c").await.is_some());
+    assert!(store.get_session("d").await.is_some());
+    assert_eq!(store.session_count().await, 3);
+}
+
+#[tokio::test]
+async fn session_store_eviction_callback_fires() {
+    let evicted_keys: Arc<std::sync::Mutex<Vec<String>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured = evicted_keys.clone();
+    let r = ServerEventRouteStore::new();
+
+    let mut store = SessionStore::with_capacity(2);
+    store.set_eviction_callback(std::sync::Arc::new(move |pubkey| {
+        captured.lock().unwrap().push(pubkey);
+    }));
+
+    store.get_or_create_session("x", false, &r).await;
+    store.get_or_create_session("y", false, &r).await;
+    // Adding "z" evicts "x"
+    store.get_or_create_session("z", false, &r).await;
+
+    let keys = evicted_keys.lock().unwrap();
+    assert_eq!(keys.len(), 1, "callback must fire exactly once");
+    assert_eq!(keys[0], "x", "evicted key must be the oldest session");
+}


### PR DESCRIPTION
Closes #5

The rmcp worker was limited to one client per instance due to an `active_client_pubkey` guard that silently dropped messages from any second client. This PR removes that restriction and adds LRU-bounded session management matching the TS SDK.

**What changed:**

`src/rmcp_transport/worker.rs` :- removed `active_client_pubkey` field and the guard that dropped messages from non-active clients. The worker now multiplexes all clients through a single rmcp service instance. Each incoming request is assigned a unique internal correlation ID (monotonic counter) before forwarding to rmcp, so clients using the same JSON-RPC request ID (e.g. both starting at `1`) don't collide. The transport layer restores the original request ID on response, so this is invisible to clients.

`src/transport/server/session_store.rs` :- replaced unbounded `HashMap` with `lru::LruCache`. Default capacity 1000, matching the TS SDK. Added eviction callback and eviction safety (sessions with pending in-flight requests are recreated with clean state instead of being dropped).

`src/transport/server/mod.rs` :- added `max_sessions: usize` to `NostrServerTransportConfig` (default 1000), wired through to the session store.

Note: a worker pool (as suggested in the issue) is not needed, the TS SDK also uses a single transport instance multiplexing all clients. The single-peer restriction was purely the `active_client_pubkey` guard.

follow-up: worker `correlation_map` is still unbounded, can be addressed in a separate PR.

