### PR TITLE
fix: wire client timeout config and add TTL sweep to prevent pending-request leak

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -128,6 +128,7 @@ mod tests {
             excluded_capabilities: vec![],
             cleanup_interval: Duration::from_secs(120),
             session_timeout: Duration::from_secs(600),
+            request_timeout: Duration::from_secs(60),
             log_file_path: None,
         };
 

--- a/src/transport/client/correlation_store.rs
+++ b/src/transport/client/correlation_store.rs
@@ -2,6 +2,7 @@
 
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use lru::LruCache;
 use tokio::sync::RwLock;
@@ -15,6 +16,8 @@ pub struct PendingRequest {
     pub original_id: serde_json::Value,
     /// Whether this request is an `initialize` handshake.
     pub is_initialize: bool,
+    /// When the request was registered.
+    pub registered_at: Instant,
 }
 
 /// Tracks pending request event IDs and their original request IDs on the client side.
@@ -59,6 +62,7 @@ impl ClientCorrelationStore {
             PendingRequest {
                 original_id,
                 is_initialize,
+                registered_at: Instant::now(),
             },
         );
     }
@@ -93,6 +97,25 @@ impl ClientCorrelationStore {
     /// Number of pending requests currently tracked.
     pub async fn count(&self) -> usize {
         self.pending_requests.read().await.len()
+    }
+
+    /// Remove all entries older than `timeout`. Returns the number of entries removed.
+    pub async fn sweep_expired(&self, timeout: Duration) -> usize {
+        let now = Instant::now();
+        let mut cache = self.pending_requests.write().await;
+        let mut expired_keys = Vec::new();
+
+        for (key, entry) in cache.iter() {
+            if now.duration_since(entry.registered_at) >= timeout {
+                expired_keys.push(key.clone());
+            }
+        }
+
+        let count = expired_keys.len();
+        for key in expired_keys {
+            cache.pop(&key);
+        }
+        count
     }
 
     pub async fn clear(&self) {
@@ -149,5 +172,41 @@ mod tests {
         assert_eq!(store.count().await, DEFAULT_LRU_SIZE);
         assert!(!store.contains("e0").await);
         assert!(store.contains(&format!("e{DEFAULT_LRU_SIZE}")).await);
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_removes_only_stale_entries() {
+        let store = ClientCorrelationStore::new();
+
+        // Insert an entry that will be "old" by the time we sweep.
+        store
+            .register("old".into(), serde_json::json!(1), false)
+            .await;
+
+        // Sleep so "old" entry ages past the threshold.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Insert a fresh entry.
+        store
+            .register("fresh".into(), serde_json::json!(2), false)
+            .await;
+
+        // Sweep with a 10ms timeout — "old" should be removed, "fresh" should remain.
+        let swept = store.sweep_expired(Duration::from_millis(10)).await;
+        assert_eq!(swept, 1);
+        assert!(!store.contains("old").await);
+        assert!(store.contains("fresh").await);
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_returns_zero_when_nothing_expired() {
+        let store = ClientCorrelationStore::new();
+        store
+            .register("e1".into(), serde_json::Value::Null, false)
+            .await;
+
+        let swept = store.sweep_expired(Duration::from_secs(60)).await;
+        assert_eq!(swept, 0);
+        assert!(store.contains("e1").await);
     }
 }

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -41,7 +41,11 @@ pub struct NostrClientTransportConfig {
     pub gift_wrap_mode: GiftWrapMode,
     /// Stateless mode: emulate initialize response locally.
     pub is_stateless: bool,
-    /// Response timeout (default: 30s).
+    /// Correlation-retention TTL for pending client requests (default: 30s).
+    ///
+    /// Stale pending entries older than this are swept from the correlation store.
+    /// This prevents leaks -- rmcp owns actual request timeout and cancellation.
+    /// Keep this value above your rmcp request timeout to avoid premature cleanup.
     pub timeout: Duration,
     /// Optional log file path. Logs always go to stdout and are also appended here when set.
     pub log_file_path: Option<String>,

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -243,6 +243,7 @@ impl NostrClientTransport {
         let init_event = self.server_initialize_event.clone();
         let server_supports_ephemeral = self.server_supports_ephemeral.clone();
         let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
+        let timeout = self.config.timeout;
 
         tokio::spawn(async move {
             Self::event_loop(
@@ -256,6 +257,7 @@ impl NostrClientTransport {
                 init_event,
                 server_supports_ephemeral,
                 seen_gift_wrap_ids,
+                timeout,
             )
             .await;
         });
@@ -393,199 +395,46 @@ impl NostrClientTransport {
         init_event: Arc<Mutex<Option<Event>>>,
         server_supports_ephemeral: Arc<AtomicBool>,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
+        timeout: Duration,
     ) {
         let mut notifications = relay_pool.notifications();
+        // Sweep interval: half the timeout, clamped to [1s, 30s].
+        let sweep_interval = (timeout / 2).clamp(Duration::from_secs(1), Duration::from_secs(30));
+        let mut sweep_timer =
+            tokio::time::interval_at(tokio::time::Instant::now() + sweep_interval, sweep_interval);
 
-        while let Ok(notification) = notifications.recv().await {
-            if let RelayPoolNotification::Event { event, .. } = notification {
-                let is_gift_wrap = is_gift_wrap_kind(&event.kind);
-                let outer_kind = event.kind.as_u16();
-
-                // Enforce encryption mode before decrypt/parse.
-                if violates_encryption_policy(&event.kind, &encryption_mode) {
-                    if is_gift_wrap {
-                        tracing::warn!(
-                            target: LOG_TARGET,
-                            event_id = %event.id.to_hex(),
-                            event_kind = outer_kind,
-                            configured_mode = ?gift_wrap_mode,
-                            "Skipping encrypted response because client encryption is disabled"
-                        );
-                    } else {
-                        tracing::warn!(
-                            target: LOG_TARGET,
-                            event_id = %event.id.to_hex(),
-                            "Skipping plaintext response because client encryption is required"
-                        );
-                    }
-                    continue;
-                }
-
-                // Enforce CEP-19 gift-wrap-mode policy.
-                if is_gift_wrap && !gift_wrap_mode.allows_kind(outer_kind) {
-                    tracing::warn!(
-                        target: LOG_TARGET,
-                        event_id = %event.id.to_hex(),
-                        event_kind = outer_kind,
-                        configured_mode = ?gift_wrap_mode,
-                        "Skipping gift wrap due to CEP-19 policy"
-                    );
-                    continue;
-                }
-
-                // Handle gift-wrapped events
-                let (actual_event_content, actual_pubkey, e_tag, verified_tags, source_event) =
-                    if is_gift_wrap {
-                        {
-                            let guard = match seen_gift_wrap_ids.lock() {
-                                Ok(g) => g,
-                                Err(poisoned) => poisoned.into_inner(),
-                            };
-                            if guard.contains(&event.id) {
-                                tracing::debug!(
-                                    target: LOG_TARGET,
-                                    event_id = %event.id.to_hex(),
-                                    "Skipping duplicate gift-wrap (outer id)"
-                                );
-                                continue;
-                            }
-                        }
-                        // Single-layer NIP-44 decrypt (matches JS/TS SDK)
-                        let signer = match relay_pool.signer().await {
-                            Ok(s) => s,
-                            Err(error) => {
-                                tracing::error!(
-                                    target: LOG_TARGET,
-                                    error = %error,
-                                    "Failed to get signer"
-                                );
-                                continue;
-                            }
-                        };
-                        match encryption::decrypt_gift_wrap_single_layer(&signer, &event).await {
-                            Ok(decrypted_json) => {
-                                match serde_json::from_str::<Event>(&decrypted_json) {
-                                    Ok(inner) => {
-                                        if let Err(e) = inner.verify() {
-                                            tracing::warn!(
-                                                "Inner event signature verification failed: {e}"
-                                            );
-                                            continue;
-                                        }
-                                        {
-                                            let mut guard = match seen_gift_wrap_ids.lock() {
-                                                Ok(g) => g,
-                                                Err(poisoned) => poisoned.into_inner(),
-                                            };
-                                            guard.put(event.id, ());
-                                        }
-                                        let e_tag = serializers::get_tag_value(&inner.tags, "e");
-                                        let inner_clone = inner.clone();
-                                        (
-                                            inner.content,
-                                            inner.pubkey,
-                                            e_tag,
-                                            inner.tags,
-                                            inner_clone,
-                                        )
-                                    }
-                                    Err(error) => {
-                                        tracing::error!(
-                                            target: LOG_TARGET,
-                                            error = %error,
-                                            "Failed to parse inner event"
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                            Err(error) => {
-                                tracing::error!(
-                                    target: LOG_TARGET,
-                                    error = %error,
-                                    "Failed to decrypt gift wrap"
-                                );
-                                continue;
-                            }
-                        }
-                    } else {
-                        let e_tag = serializers::get_tag_value(&event.tags, "e");
-                        let event_clone = (*event).clone();
-                        (
-                            event.content.clone(),
-                            event.pubkey,
-                            e_tag,
-                            event.tags.clone(),
-                            event_clone,
-                        )
+        loop {
+            tokio::select! {
+                result = notifications.recv() => {
+                    let notification = match result {
+                        Ok(n) => n,
+                        Err(_) => break,
                     };
-
-                // Verify it's from our server
-                if actual_pubkey != server_pubkey {
-                    tracing::debug!(
-                        target: LOG_TARGET,
-                        event_pubkey = %actual_pubkey.to_hex(),
-                        expected_pubkey = %server_pubkey.to_hex(),
-                        "Skipping event from unexpected pubkey"
-                    );
-                    continue;
+                    Self::handle_notification(
+                        &notification,
+                        &pending,
+                        server_pubkey,
+                        &tx,
+                        encryption_mode,
+                        gift_wrap_mode,
+                        &discovered_caps,
+                        &init_event,
+                        &server_supports_ephemeral,
+                        &seen_gift_wrap_ids,
+                        &relay_pool,
+                    )
+                    .await;
                 }
-
-                // CEP-35: learn server capabilities from discovery tags
-                Self::learn_server_discovery(&discovered_caps, &init_event, &source_event);
-
-                // CEP-19: learn ephemeral support from server
-                if Self::should_learn_ephemeral_support(
-                    actual_pubkey,
-                    server_pubkey,
-                    if is_gift_wrap { Some(outer_kind) } else { None },
-                    &verified_tags,
-                ) {
-                    server_supports_ephemeral.store(true, Ordering::Relaxed);
-                }
-
-                // Correlate response
-                if let Some(ref correlated_id) = e_tag {
-                    let is_pending = pending.contains(correlated_id.as_str()).await;
-                    if !is_pending {
+                _ = sweep_timer.tick() => {
+                    let swept = pending.sweep_expired(timeout).await;
+                    if swept > 0 {
                         tracing::warn!(
                             target: LOG_TARGET,
-                            correlated_event_id = %correlated_id,
-                            "Response for unknown request"
+                            swept,
+                            timeout_ms = timeout.as_millis() as u64,
+                            "Swept stale pending requests (rmcp handles timeout errors)"
                         );
-                        continue;
                     }
-                }
-
-                // Parse MCP message
-                if let Some(mcp_msg) = validation::validate_and_parse(&actual_event_content) {
-                    // Drop uncorrelated responses and server-to-client requests (matches TS SDK).
-                    match &mcp_msg {
-                        JsonRpcMessage::Response(_) | JsonRpcMessage::ErrorResponse(_)
-                            if e_tag.is_none() =>
-                        {
-                            tracing::warn!(
-                                target: LOG_TARGET,
-                                "Dropping response/error without correlation `e` tag"
-                            );
-                            continue;
-                        }
-                        JsonRpcMessage::Request(_) => {
-                            tracing::warn!(
-                                target: LOG_TARGET,
-                                method = ?mcp_msg.method(),
-                                "Dropping server-to-client request (invalid in MCP)"
-                            );
-                            continue;
-                        }
-                        _ => {}
-                    }
-
-                    // Clean up pending request
-                    if let Some(ref correlated_id) = e_tag {
-                        pending.remove(correlated_id.as_str()).await;
-                    }
-                    let _ = tx.send(mcp_msg);
                 }
             }
         }
@@ -673,6 +522,206 @@ impl NostrClientTransport {
         *guard
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_notification(
+        notification: &RelayPoolNotification,
+        pending: &ClientCorrelationStore,
+        server_pubkey: PublicKey,
+        tx: &tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
+        encryption_mode: EncryptionMode,
+        gift_wrap_mode: GiftWrapMode,
+        discovered_caps: &Arc<Mutex<PeerCapabilities>>,
+        init_event: &Arc<Mutex<Option<Event>>>,
+        server_supports_ephemeral: &Arc<AtomicBool>,
+        seen_gift_wrap_ids: &Arc<Mutex<LruCache<EventId, ()>>>,
+        relay_pool: &Arc<dyn RelayPoolTrait>,
+    ) {
+        let event = match notification {
+            RelayPoolNotification::Event { event, .. } => event,
+            _ => return,
+        };
+
+        let is_gift_wrap = is_gift_wrap_kind(&event.kind);
+        let outer_kind = event.kind.as_u16();
+
+        // Enforce encryption mode before decrypt/parse.
+        if violates_encryption_policy(&event.kind, &encryption_mode) {
+            if is_gift_wrap {
+                tracing::warn!(
+                    target: LOG_TARGET,
+                    event_id = %event.id.to_hex(),
+                    event_kind = outer_kind,
+                    configured_mode = ?gift_wrap_mode,
+                    "Skipping encrypted response because client encryption is disabled"
+                );
+            } else {
+                tracing::warn!(
+                    target: LOG_TARGET,
+                    event_id = %event.id.to_hex(),
+                    "Skipping plaintext response because client encryption is required"
+                );
+            }
+            return;
+        }
+
+        // Enforce CEP-19 gift-wrap-mode policy.
+        if is_gift_wrap && !gift_wrap_mode.allows_kind(outer_kind) {
+            tracing::warn!(
+                target: LOG_TARGET,
+                event_id = %event.id.to_hex(),
+                event_kind = outer_kind,
+                configured_mode = ?gift_wrap_mode,
+                "Skipping gift wrap due to CEP-19 policy"
+            );
+            return;
+        }
+
+        // Handle gift-wrapped events
+        let (actual_event_content, actual_pubkey, e_tag, verified_tags, source_event) =
+            if is_gift_wrap {
+                {
+                    let guard = match seen_gift_wrap_ids.lock() {
+                        Ok(g) => g,
+                        Err(poisoned) => poisoned.into_inner(),
+                    };
+                    if guard.contains(&event.id) {
+                        tracing::debug!(
+                            target: LOG_TARGET,
+                            event_id = %event.id.to_hex(),
+                            "Skipping duplicate gift-wrap (outer id)"
+                        );
+                        return;
+                    }
+                }
+                // Single-layer NIP-44 decrypt (matches JS/TS SDK)
+                let signer = match relay_pool.signer().await {
+                    Ok(s) => s,
+                    Err(error) => {
+                        tracing::error!(
+                            target: LOG_TARGET,
+                            error = %error,
+                            "Failed to get signer"
+                        );
+                        return;
+                    }
+                };
+                match encryption::decrypt_gift_wrap_single_layer(&signer, event).await {
+                    Ok(decrypted_json) => match serde_json::from_str::<Event>(&decrypted_json) {
+                        Ok(inner) => {
+                            if let Err(e) = inner.verify() {
+                                tracing::warn!("Inner event signature verification failed: {e}");
+                                return;
+                            }
+                            {
+                                let mut guard = match seen_gift_wrap_ids.lock() {
+                                    Ok(g) => g,
+                                    Err(poisoned) => poisoned.into_inner(),
+                                };
+                                guard.put(event.id, ());
+                            }
+                            let e_tag = serializers::get_tag_value(&inner.tags, "e");
+                            let inner_clone = inner.clone();
+                            (inner.content, inner.pubkey, e_tag, inner.tags, inner_clone)
+                        }
+                        Err(error) => {
+                            tracing::error!(
+                                target: LOG_TARGET,
+                                error = %error,
+                                "Failed to parse inner event"
+                            );
+                            return;
+                        }
+                    },
+                    Err(error) => {
+                        tracing::error!(
+                            target: LOG_TARGET,
+                            error = %error,
+                            "Failed to decrypt gift wrap"
+                        );
+                        return;
+                    }
+                }
+            } else {
+                let e_tag = serializers::get_tag_value(&event.tags, "e");
+                let event_clone: Event = (**event).clone();
+                (
+                    event.content.clone(),
+                    event.pubkey,
+                    e_tag,
+                    event.tags.clone(),
+                    event_clone,
+                )
+            };
+
+        // Verify it's from our server
+        if actual_pubkey != server_pubkey {
+            tracing::debug!(
+                target: LOG_TARGET,
+                event_pubkey = %actual_pubkey.to_hex(),
+                expected_pubkey = %server_pubkey.to_hex(),
+                "Skipping event from unexpected pubkey"
+            );
+            return;
+        }
+
+        // CEP-35: learn server capabilities from discovery tags
+        Self::learn_server_discovery(discovered_caps, init_event, &source_event);
+
+        // CEP-19: learn ephemeral support from server
+        if Self::should_learn_ephemeral_support(
+            actual_pubkey,
+            server_pubkey,
+            if is_gift_wrap { Some(outer_kind) } else { None },
+            &verified_tags,
+        ) {
+            server_supports_ephemeral.store(true, Ordering::Relaxed);
+        }
+
+        // Correlate response
+        if let Some(ref correlated_id) = e_tag {
+            let is_pending = pending.contains(correlated_id.as_str()).await;
+            if !is_pending {
+                tracing::warn!(
+                    target: LOG_TARGET,
+                    correlated_event_id = %correlated_id,
+                    "Response for unknown request"
+                );
+                return;
+            }
+        }
+
+        // Parse MCP message
+        if let Some(mcp_msg) = validation::validate_and_parse(&actual_event_content) {
+            // Drop uncorrelated responses and server-to-client requests (matches TS SDK).
+            match &mcp_msg {
+                JsonRpcMessage::Response(_) | JsonRpcMessage::ErrorResponse(_)
+                    if e_tag.is_none() =>
+                {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        "Dropping response/error without correlation `e` tag"
+                    );
+                    return;
+                }
+                JsonRpcMessage::Request(_) => {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        method = ?mcp_msg.method(),
+                        "Dropping server-to-client request (invalid in MCP)"
+                    );
+                    return;
+                }
+                _ => {}
+            }
+
+            // Clean up pending request
+            if let Some(ref correlated_id) = e_tag {
+                pending.remove(correlated_id.as_str()).await;
+            }
+            let _ = tx.send(mcp_msg);
+        }
+    }
+
     fn choose_outbound_gift_wrap_kind(&self) -> u16 {
         match self.config.gift_wrap_mode {
             GiftWrapMode::Persistent => GIFT_WRAP_KIND,
@@ -750,6 +799,15 @@ mod tests {
             ..Default::default()
         };
         assert!(config.is_stateless);
+    }
+
+    #[test]
+    fn test_custom_timeout_config() {
+        let config = NostrClientTransportConfig {
+            timeout: Duration::from_secs(60),
+            ..Default::default()
+        };
+        assert_eq!(config.timeout, Duration::from_secs(60));
     }
 
     #[test]

--- a/src/transport/server/correlation_store.rs
+++ b/src/transport/server/correlation_store.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use lru::LruCache;
 use tokio::sync::RwLock;
@@ -21,6 +22,8 @@ pub struct RouteEntry {
     /// The outer gift-wrap event kind that carried this request (e.g. 1059 or 21059).
     /// Populated from the inbound event in a later PR; `None` until then.
     pub wrap_kind: Option<u16>,
+    /// When the route was registered.
+    pub registered_at: Instant,
 }
 
 /// Internal state behind the lock.
@@ -127,6 +130,7 @@ impl ServerEventRouteStore {
                 original_request_id,
                 progress_token,
                 wrap_kind: None,
+                registered_at: Instant::now(),
             },
         );
 
@@ -220,6 +224,26 @@ impl ServerEventRouteStore {
     /// Number of progress token mappings currently tracked.
     pub async fn progress_token_count(&self) -> usize {
         self.inner.read().await.progress_token_to_event.len()
+    }
+
+    /// Remove all route entries older than `timeout`.
+    /// (Routes for expired sessions are already cleaned by `cleanup_sessions`.)
+    /// Returns the event IDs of the removed entries.
+    pub async fn sweep_stale_routes(&self, timeout: Duration) -> Vec<String> {
+        let now = Instant::now();
+        let mut inner = self.inner.write().await;
+        let mut expired_keys = Vec::new();
+
+        for (key, entry) in inner.routes.iter() {
+            if now.duration_since(entry.registered_at) >= timeout {
+                expired_keys.push(key.clone());
+            }
+        }
+
+        for key in &expired_keys {
+            inner.remove_route(key);
+        }
+        expired_keys
     }
 
     pub async fn clear(&self) {
@@ -320,5 +344,44 @@ mod tests {
         assert_eq!(store.event_route_count().await, DEFAULT_LRU_SIZE);
         assert!(!store.has_event_route("e0").await);
         assert!(store.has_event_route(&format!("e{DEFAULT_LRU_SIZE}")).await);
+    }
+
+    #[tokio::test]
+    async fn sweep_stale_routes_removes_only_expired() {
+        let store = ServerEventRouteStore::new();
+
+        // Insert a route that will age past the threshold.
+        store
+            .register("old".into(), "pk1".into(), json!(1), Some("tok1".into()))
+            .await;
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Insert a fresh route.
+        store
+            .register("fresh".into(), "pk2".into(), json!(2), None)
+            .await;
+
+        // Sweep with 10ms timeout — "old" should be removed, "fresh" should remain.
+        let swept = store.sweep_stale_routes(Duration::from_millis(10)).await;
+        assert_eq!(swept.len(), 1);
+        assert_eq!(swept[0], "old");
+        assert!(!store.has_event_route("old").await);
+        assert!(store.has_event_route("fresh").await);
+        // Secondary indexes should also be cleaned.
+        assert!(!store.has_progress_token("tok1").await);
+        assert!(!store.has_active_routes_for_client("pk1").await);
+    }
+
+    #[tokio::test]
+    async fn sweep_stale_routes_returns_zero_when_nothing_expired() {
+        let store = ServerEventRouteStore::new();
+        store
+            .register("e1".into(), "pk1".into(), json!(1), None)
+            .await;
+
+        let swept = store.sweep_stale_routes(Duration::from_secs(60)).await;
+        assert!(swept.is_empty());
+        assert!(store.has_event_route("e1").await);
     }
 }

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -52,7 +52,11 @@ pub struct NostrServerTransportConfig {
     pub cleanup_interval: Duration,
     /// Session timeout (default: 300s).
     pub session_timeout: Duration,
-    /// Request route timeout (default: 60s). Stale routes older than this are swept.
+    /// Correlation-retention TTL for server-side event routes (default: 60s).
+    ///
+    /// Stale route entries older than this are swept from the correlation store.
+    /// This prevents leaks -- rmcp owns actual request timeout and cancellation.
+    /// Keep this value above your rmcp request timeout to avoid premature cleanup.
     pub request_timeout: Duration,
     /// Optional log file path. Logs always go to stdout and are also appended here when set.
     pub log_file_path: Option<String>,

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -52,6 +52,8 @@ pub struct NostrServerTransportConfig {
     pub cleanup_interval: Duration,
     /// Session timeout (default: 300s).
     pub session_timeout: Duration,
+    /// Request route timeout (default: 60s). Stale routes older than this are swept.
+    pub request_timeout: Duration,
     /// Optional log file path. Logs always go to stdout and are also appended here when set.
     pub log_file_path: Option<String>,
 }
@@ -68,6 +70,7 @@ impl Default for NostrServerTransportConfig {
             excluded_capabilities: Vec::new(),
             cleanup_interval: Duration::from_secs(60),
             session_timeout: Duration::from_secs(300),
+            request_timeout: Duration::from_secs(60),
             log_file_path: None,
         }
     }
@@ -277,6 +280,7 @@ impl NostrServerTransport {
         let request_wrap_kinds_cleanup = self.request_wrap_kinds.clone();
         let cleanup_interval = self.config.cleanup_interval;
         let session_timeout = self.config.session_timeout;
+        let request_timeout = self.config.request_timeout;
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(cleanup_interval);
@@ -294,6 +298,24 @@ impl NostrServerTransport {
                         target: LOG_TARGET,
                         cleaned_sessions = cleaned,
                         "Cleaned up inactive sessions"
+                    );
+                }
+
+                // Sweep stale route entries in active sessions (rmcp handles timeout errors).
+                let swept_event_ids = event_routes_cleanup
+                    .sweep_stale_routes(request_timeout)
+                    .await;
+                if !swept_event_ids.is_empty() {
+                    let mut kinds_w = request_wrap_kinds_cleanup.write().await;
+                    for event_id in &swept_event_ids {
+                        kinds_w.remove(event_id);
+                    }
+                    drop(kinds_w);
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        swept = swept_event_ids.len(),
+                        timeout_secs = request_timeout.as_secs(),
+                        "Swept stale event routes (rmcp handles timeout errors)"
                     );
                 }
             }
@@ -1503,6 +1525,7 @@ mod tests {
         assert!(config.excluded_capabilities.is_empty());
         assert_eq!(config.cleanup_interval, Duration::from_secs(60));
         assert_eq!(config.session_timeout, Duration::from_secs(300));
+        assert_eq!(config.request_timeout, Duration::from_secs(60));
         assert!(config.server_info.is_none());
         assert!(config.log_file_path.is_none());
     }


### PR DESCRIPTION
Closes #33 (supersedes it with a cleaner approach)

The timeout config was defined but never referenced anywhere, so unanswered requests accumulated in the correlation store indefinitely (bounded only by LRU capacity, not by time).

After checking how rmcp handles timeouts - it does, with proper MCP cancellation notifications -- the right fix is to clean up the transport-layer correlation entries without duplicating rmcp's error propagation.

Changes:

Added `registered_at` timestamps to `PendingRequest` and `RouteEntry`. Client event loop now runs a periodic TTL sweep (every timeout/2, clamped to 1s-30s) that removes entries older than `config.timeout` (default 30s) and logs a warning. No synthetic error responses -- rmcp already handles the error path.

Server cleanup task extended to also sweep stale routes older than `config.request_timeout` (new field, default 60s). Swept route IDs are also removed from `request_wrap_kinds` to prevent a secondary leak. Symmetric with the client fix as gzzz suggested.

4 new unit tests covering stale entry removal, fresh entry preservation, and secondary index cleanup.

