### PR TITLE
fix: stop event loop tasks on close()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ rmcp = { version = "0.16.0", features = ["server", "client", "macros", "transpor
 # LRU cache for gift-wrap (outer event id) deduplication
 lru = "0.12"
 
+# CancellationToken for graceful event-loop shutdown
+tokio-util = { version = "0.7", features = ["rt"] }
+
 [features]
 # Enable rmcp by default while keeping legacy APIs available.
 default = ["rmcp"]

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
+use tokio_util::sync::CancellationToken;
 
 use crate::core::constants::*;
 use crate::core::error::{Error, Result};
@@ -85,8 +86,12 @@ pub struct NostrClientTransport {
     /// so failed decrypt/verify can be retried on redelivery.
     seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     /// Channel for receiving processed MCP messages from the event loop.
-    message_tx: tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>,
+    message_tx: Option<tokio::sync::mpsc::UnboundedSender<JsonRpcMessage>>,
     message_rx: Option<tokio::sync::mpsc::UnboundedReceiver<JsonRpcMessage>>,
+    /// Token used to cancel the spawned event loop on close().
+    cancellation_token: CancellationToken,
+    /// Handle for the spawned event loop task.
+    event_loop_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl NostrClientTransport {
@@ -142,8 +147,10 @@ impl NostrClientTransport {
             server_initialize_event: Arc::new(Mutex::new(None)),
             server_supports_ephemeral: Arc::new(AtomicBool::new(false)),
             seen_gift_wrap_ids,
-            message_tx: tx,
+            message_tx: Some(tx),
             message_rx: Some(rx),
+            cancellation_token: CancellationToken::new(),
+            event_loop_handle: None,
         })
     }
 
@@ -190,8 +197,10 @@ impl NostrClientTransport {
             server_initialize_event: Arc::new(Mutex::new(None)),
             server_supports_ephemeral: Arc::new(AtomicBool::new(false)),
             seen_gift_wrap_ids,
-            message_tx: tx,
+            message_tx: Some(tx),
             message_rx: Some(rx),
+            cancellation_token: CancellationToken::new(),
+            event_loop_handle: None,
         })
     }
 
@@ -236,11 +245,15 @@ impl NostrClientTransport {
                 error
             })?;
 
-        // Spawn event loop
+        // Spawn event loop with cancellation support
         let relay_pool = Arc::clone(&self.base.relay_pool);
         let pending = self.pending_requests.clone();
         let server_pubkey = self.server_pubkey;
-        let tx = self.message_tx.clone();
+        let tx = self
+            .message_tx
+            .as_ref()
+            .expect("message_tx must exist before start()")
+            .clone();
         let encryption_mode = self.config.encryption_mode;
         let gift_wrap_mode = self.config.gift_wrap_mode;
         let discovered_caps = self.discovered_server_capabilities.clone();
@@ -248,8 +261,9 @@ impl NostrClientTransport {
         let server_supports_ephemeral = self.server_supports_ephemeral.clone();
         let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
         let timeout = self.config.timeout;
+        let token = self.cancellation_token.child_token();
 
-        tokio::spawn(async move {
+        self.event_loop_handle = Some(tokio::spawn(async move {
             Self::event_loop(
                 relay_pool,
                 pending,
@@ -262,9 +276,10 @@ impl NostrClientTransport {
                 server_supports_ephemeral,
                 seen_gift_wrap_ids,
                 timeout,
+                token,
             )
             .await;
-        });
+        }));
 
         tracing::info!(
             target: LOG_TARGET,
@@ -274,8 +289,13 @@ impl NostrClientTransport {
         Ok(())
     }
 
-    /// Close the transport.
+    /// Close the transport — cancels the event loop and disconnects from relays.
     pub async fn close(&mut self) -> Result<()> {
+        self.cancellation_token.cancel();
+        if let Some(handle) = self.event_loop_handle.take() {
+            let _ = handle.await;
+        }
+        self.message_tx.take();
         self.base.disconnect().await
     }
 
@@ -384,7 +404,9 @@ impl NostrClientTransport {
                 }
             }),
         });
-        let _ = self.message_tx.send(response);
+        if let Some(ref tx) = self.message_tx {
+            let _ = tx.send(response);
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -400,6 +422,7 @@ impl NostrClientTransport {
         server_supports_ephemeral: Arc<AtomicBool>,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
         timeout: Duration,
+        cancel: CancellationToken,
     ) {
         let mut notifications = relay_pool.notifications();
         // Sweep interval: half the timeout, clamped to [1s, 30s].
@@ -409,6 +432,13 @@ impl NostrClientTransport {
 
         loop {
             tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::info!(
+                        target: LOG_TARGET,
+                        "Client event loop cancelled"
+                    );
+                    break;
+                }
                 result = notifications.recv() => {
                     let notification = match result {
                         Ok(n) => n,
@@ -1035,8 +1065,10 @@ mod tests {
             server_initialize_event: Arc::new(Mutex::new(None)),
             server_supports_ephemeral: Arc::new(AtomicBool::new(false)),
             seen_gift_wrap_ids: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(10).unwrap()))),
-            message_tx: tokio::sync::mpsc::unbounded_channel().0,
+            message_tx: Some(tokio::sync::mpsc::unbounded_channel().0),
             message_rx: None,
+            cancellation_token: CancellationToken::new(),
+            event_loop_handle: None,
         }
     }
 

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
+use tokio_util::sync::CancellationToken;
 
 use crate::core::constants::*;
 use crate::core::error::{Error, Result};
@@ -104,8 +105,12 @@ pub struct NostrServerTransport {
     /// so failed decrypt/verify can be retried on redelivery.
     seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
     /// Channel for incoming MCP messages (consumed by the MCP server).
-    message_tx: tokio::sync::mpsc::UnboundedSender<IncomingRequest>,
+    message_tx: Option<tokio::sync::mpsc::UnboundedSender<IncomingRequest>>,
     message_rx: Option<tokio::sync::mpsc::UnboundedReceiver<IncomingRequest>>,
+    /// Token used to cancel spawned tasks (event loop + cleanup) on close().
+    cancellation_token: CancellationToken,
+    /// Handles for spawned tasks (event loop + cleanup).
+    task_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 /// An incoming MCP request with metadata for routing the response.
@@ -164,8 +169,10 @@ impl NostrServerTransport {
             event_routes: ServerEventRouteStore::new(),
             request_wrap_kinds: Arc::new(RwLock::new(HashMap::new())),
             seen_gift_wrap_ids,
-            message_tx: tx,
+            message_tx: Some(tx),
             message_rx: Some(rx),
+            cancellation_token: CancellationToken::new(),
+            task_handles: Vec::new(),
         })
     }
 
@@ -201,8 +208,10 @@ impl NostrServerTransport {
             request_wrap_kinds: Arc::new(RwLock::new(HashMap::new())),
             event_routes: ServerEventRouteStore::new(),
             seen_gift_wrap_ids,
-            message_tx: tx,
+            message_tx: Some(tx),
             message_rx: Some(rx),
+            cancellation_token: CancellationToken::new(),
+            task_handles: Vec::new(),
         })
     }
 
@@ -247,12 +256,16 @@ impl NostrServerTransport {
                 error
             })?;
 
-        // Spawn event loop
+        // Spawn event loop with cancellation support
         let relay_pool = Arc::clone(&self.base.relay_pool);
         let sessions = self.sessions.clone();
         let event_routes = self.event_routes.clone();
         let request_wrap_kinds = self.request_wrap_kinds.clone();
-        let tx = self.message_tx.clone();
+        let tx = self
+            .message_tx
+            .as_ref()
+            .expect("message_tx must exist before start()")
+            .clone();
         let allowed = self.config.allowed_public_keys.clone();
         let excluded = self.config.excluded_capabilities.clone();
         let encryption_mode = self.config.encryption_mode;
@@ -261,8 +274,9 @@ impl NostrServerTransport {
         let server_info = self.config.server_info.clone();
         let extra_common_tags = self.extra_common_tags.clone();
         let seen_gift_wrap_ids = self.seen_gift_wrap_ids.clone();
+        let event_loop_token = self.cancellation_token.child_token();
 
-        tokio::spawn(async move {
+        let event_loop_handle = tokio::spawn(async move {
             Self::event_loop(
                 relay_pool,
                 sessions,
@@ -277,35 +291,47 @@ impl NostrServerTransport {
                 server_info,
                 extra_common_tags,
                 seen_gift_wrap_ids,
+                event_loop_token,
             )
             .await;
         });
 
-        // Spawn session cleanup
+        // Spawn session cleanup with cancellation support
         let sessions_cleanup = self.sessions.clone();
         let event_routes_cleanup = self.event_routes.clone();
         let request_wrap_kinds_cleanup = self.request_wrap_kinds.clone();
         let cleanup_interval = self.config.cleanup_interval;
         let session_timeout = self.config.session_timeout;
         let request_timeout = self.config.request_timeout;
+        let cleanup_token = self.cancellation_token.child_token();
 
-        tokio::spawn(async move {
+        let cleanup_handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(cleanup_interval);
             loop {
-                interval.tick().await;
-                let cleaned = Self::cleanup_sessions(
-                    &sessions_cleanup,
-                    &event_routes_cleanup,
-                    &request_wrap_kinds_cleanup,
-                    session_timeout,
-                )
-                .await;
-                if cleaned > 0 {
-                    tracing::info!(
-                        target: LOG_TARGET,
-                        cleaned_sessions = cleaned,
-                        "Cleaned up inactive sessions"
-                    );
+                tokio::select! {
+                    _ = cleanup_token.cancelled() => {
+                        tracing::info!(
+                            target: LOG_TARGET,
+                            "Server cleanup task cancelled"
+                        );
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let cleaned = Self::cleanup_sessions(
+                            &sessions_cleanup,
+                            &event_routes_cleanup,
+                            &request_wrap_kinds_cleanup,
+                            session_timeout,
+                        )
+                        .await;
+                        if cleaned > 0 {
+                            tracing::info!(
+                                target: LOG_TARGET,
+                                cleaned_sessions = cleaned,
+                                "Cleaned up inactive sessions"
+                            );
+                        }
+                    }
                 }
 
                 // Sweep stale route entries in active sessions (rmcp handles timeout errors).
@@ -328,6 +354,9 @@ impl NostrServerTransport {
             }
         });
 
+        self.task_handles.push(event_loop_handle);
+        self.task_handles.push(cleanup_handle);
+
         tracing::info!(
             target: LOG_TARGET,
             relay_count = self.config.relay_urls.len(),
@@ -338,8 +367,13 @@ impl NostrServerTransport {
         Ok(())
     }
 
-    /// Close the transport.
+    /// Close the transport — cancels event loop and cleanup tasks, then disconnects.
     pub async fn close(&mut self) -> Result<()> {
+        self.cancellation_token.cancel();
+        for handle in self.task_handles.drain(..) {
+            let _ = handle.await;
+        }
+        self.message_tx.take();
         self.base.disconnect().await?;
         self.sessions.clear().await;
         self.event_routes.clear().await;
@@ -849,10 +883,26 @@ impl NostrServerTransport {
         server_info: Option<ServerInfo>,
         extra_common_tags: Vec<Tag>,
         seen_gift_wrap_ids: Arc<Mutex<LruCache<EventId, ()>>>,
+        cancel: CancellationToken,
     ) {
         let mut notifications = relay_pool.notifications();
 
-        while let Ok(notification) = notifications.recv().await {
+        loop {
+            let notification = tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::info!(
+                        target: LOG_TARGET,
+                        "Server event loop cancelled"
+                    );
+                    break;
+                }
+                result = notifications.recv() => {
+                    match result {
+                        Ok(n) => n,
+                        Err(_) => break,
+                    }
+                }
+            };
             if let RelayPoolNotification::Event { event, .. } = notification {
                 let is_gift_wrap = event.kind == Kind::Custom(GIFT_WRAP_KIND)
                     || event.kind == Kind::Custom(EPHEMERAL_GIFT_WRAP_KIND);

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -3523,3 +3523,65 @@ async fn session_store_eviction_callback_fires() {
     assert_eq!(keys.len(), 1, "callback must fire exactly once");
     assert_eq!(keys[0], "x", "evicted key must be the oldest session");
 }
+
+// ── Event loop cancellation on close() ──────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn client_close_stops_event_loop() {
+    let (client_pool, server_pool) = MockRelayPool::create_pair();
+    let server_pubkey = server_pool.mock_public_key();
+
+    let mut client = NostrClientTransport::with_relay_pool(
+        NostrClientTransportConfig {
+            server_pubkey: server_pubkey.to_hex(),
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(client_pool),
+    )
+    .await
+    .expect("create client transport");
+
+    let mut rx = client.take_message_receiver().expect("message receiver");
+    client.start().await.expect("client start");
+    let_event_loops_start().await;
+
+    // Close should cancel the event loop, causing the rx channel to close.
+    client.close().await.expect("client close");
+
+    // The receiver must resolve to None (closed) within a short timeout.
+    let result = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+    assert!(
+        matches!(result, Ok(None)),
+        "after close(), message receiver must yield None (channel closed)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_close_stops_event_loop() {
+    let (_client_pool, server_pool) = MockRelayPool::create_pair();
+
+    let mut server = NostrServerTransport::with_relay_pool(
+        NostrServerTransportConfig {
+            encryption_mode: EncryptionMode::Disabled,
+            ..Default::default()
+        },
+        as_pool(server_pool),
+    )
+    .await
+    .expect("create server transport");
+
+    let mut rx = server.take_message_receiver().expect("message receiver");
+    server.start().await.expect("server start");
+    let_event_loops_start().await;
+
+    // Close should cancel both event loop and cleanup tasks.
+    server.close().await.expect("server close");
+
+    // The receiver must resolve to None (closed) within a short timeout.
+    let result = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+    assert!(
+        matches!(result, Ok(None)),
+        "after close(), message receiver must yield None (channel closed)"
+    );
+}


### PR DESCRIPTION
Closes #62 

Spawned Tokio tasks (event loop + server cleanup) were never cancelled when close() was called. They kept running until the process exited, leaking resources in any server that creates and closes transports over its lifetime.

Added a CancellationToken (tokio-util) to both NostrClientTransport and NostrServerTransport. close() now cancels the token, awaits the task handles to confirm they've exited, then drops the message sender before disconnecting.

The fix covers:
- Client event loop task
- Server event loop task  
- Server session cleanup task

Also cleared the pre-existing dead code warning on get_tag_value in the integration tests while i was in there.

2 new tests verify that calling close() actually stops the event loop - both client and server, by checking the message channel closes cleanly after shutdown.

