### PR TITLE
refactor(rmcp): add direct transport adapters for native ContextVM se…

### DIFF
--- a/examples/native_echo_client.rs
+++ b/examples/native_echo_client.rs
@@ -1,0 +1,96 @@
+//! Example: Native rmcp client over ContextVM/Nostr.
+//!
+//! Usage:
+//!   cargo run --example native_echo_client -- <server_pubkey_hex>
+
+use anyhow::{Context, Result};
+use contextvm_sdk::transport::client::{NostrClientTransport, NostrClientTransportConfig};
+use contextvm_sdk::{signer, EncryptionMode, GiftWrapMode};
+use rmcp::{
+    model::{CallToolRequestParams, CallToolResult},
+    ClientHandler, ServiceExt,
+};
+
+const RELAY_URL: &str = "wss://relay.contextvm.org";
+
+#[derive(Clone, Default)]
+struct EchoClient;
+
+impl ClientHandler for EchoClient {}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("contextvm_sdk=info".parse()?)
+                .add_directive("rmcp=warn".parse()?),
+        )
+        .init();
+
+    let server_pubkey = std::env::args()
+        .nth(1)
+        .context("Usage: native_echo_client <server_pubkey_hex>")?;
+
+    let signer = signer::generate();
+    println!("Native ContextVM echo client starting");
+    println!("Relay: {RELAY_URL}");
+    println!("Client pubkey: {}", signer.public_key().to_hex());
+    println!("Target server pubkey: {server_pubkey}");
+
+    let transport = NostrClientTransport::new(
+        signer,
+        NostrClientTransportConfig {
+            relay_urls: vec![RELAY_URL.to_string()],
+            server_pubkey,
+            encryption_mode: EncryptionMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Optional,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let client = EchoClient.serve(transport.into_rmcp_transport()).await?;
+
+    let peer_info = client
+        .peer_info()
+        .context("server did not provide peer info after initialize")?;
+    println!("Connected to: {:?}", peer_info.server_info.name);
+
+    let tools = client.list_all_tools().await?;
+    println!("Discovered {} tool(s):", tools.len());
+    for tool in &tools {
+        println!("- {}", tool.name);
+    }
+
+    let result = client
+        .call_tool(CallToolRequestParams {
+            name: "echo".into(),
+            arguments: serde_json::from_value(serde_json::json!({
+                "message": "hello from native contextvm client"
+            }))
+            .ok(),
+            meta: None,
+            task: None,
+        })
+        .await?;
+
+    println!("Echo result: {}", first_text(&result));
+
+    client.cancel().await?;
+    Ok(())
+}
+
+fn first_text(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .find_map(|content| {
+            if let rmcp::model::RawContent::Text(text) = &content.raw {
+                Some(text.text.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}

--- a/examples/native_echo_client.rs
+++ b/examples/native_echo_client.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    let client = EchoClient.serve(transport.into_rmcp_transport()).await?;
+    let client = EchoClient.serve(transport).await?;
 
     let peer_info = client
         .peer_info()

--- a/examples/native_echo_server.rs
+++ b/examples/native_echo_server.rs
@@ -98,9 +98,7 @@ async fn main() -> Result<()> {
     )
     .await?;
 
-    let service = EchoServer::new()
-        .serve(transport.into_rmcp_transport())
-        .await?;
+    let service = EchoServer::new().serve(transport).await?;
     println!("Server ready. Press Ctrl+C to stop.");
     service.waiting().await?;
     Ok(())

--- a/examples/native_echo_server.rs
+++ b/examples/native_echo_server.rs
@@ -1,0 +1,107 @@
+//! Example: Native rmcp echo server over ContextVM/Nostr.
+//!
+//! Usage:
+//!   cargo run --example native_echo_server
+
+use anyhow::Result;
+use contextvm_sdk::transport::server::{NostrServerTransport, NostrServerTransportConfig};
+use contextvm_sdk::{signer, EncryptionMode, GiftWrapMode, ServerInfo};
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::*,
+    schemars, tool, tool_handler, tool_router, ServerHandler, ServiceExt,
+};
+
+const RELAY_URL: &str = "wss://relay.contextvm.org";
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct EchoParams {
+    message: String,
+}
+
+#[derive(Clone)]
+struct EchoServer {
+    tool_router: ToolRouter<Self>,
+}
+
+impl EchoServer {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+#[tool_router]
+impl EchoServer {
+    #[tool(description = "Echo a message back unchanged")]
+    async fn echo(
+        &self,
+        Parameters(EchoParams { message }): Parameters<EchoParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Echo: {message}"
+        ))]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for EchoServer {
+    fn get_info(&self) -> rmcp::model::ServerInfo {
+        rmcp::model::ServerInfo {
+            protocol_version: ProtocolVersion::LATEST,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation {
+                name: "contextvm-native-echo".to_string(),
+                title: Some("ContextVM Native Echo Server".to_string()),
+                version: "0.1.0".to_string(),
+                description: Some("Native rmcp echo server over ContextVM/Nostr".to_string()),
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some("Call the echo tool with a message string".to_string()),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("contextvm_sdk=info".parse()?)
+                .add_directive("rmcp=warn".parse()?),
+        )
+        .init();
+
+    let signer = signer::generate();
+    let pubkey = signer.public_key().to_hex();
+
+    println!("Native ContextVM echo server starting");
+    println!("Relay: {RELAY_URL}");
+    println!("Server pubkey: {pubkey}");
+
+    let transport = NostrServerTransport::new(
+        signer,
+        NostrServerTransportConfig {
+            relay_urls: vec![RELAY_URL.to_string()],
+            encryption_mode: EncryptionMode::Optional,
+            gift_wrap_mode: GiftWrapMode::Optional,
+            is_announced_server: false,
+            server_info: Some(ServerInfo {
+                name: Some("contextvm-native-echo".to_string()),
+                about: Some("Native rmcp echo server example".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let service = EchoServer::new()
+        .serve(transport.into_rmcp_transport())
+        .await?;
+    println!("Server ready. Press Ctrl+C to stop.");
+    service.waiting().await?;
+    Ok(())
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -84,7 +84,7 @@ impl NostrMCPGateway {
     /// Start a gateway directly from an rmcp server handler.
     ///
     /// This additive API keeps the existing `new/start/send_response` flow intact,
-    /// while allowing rmcp-first usage through the worker adapter.
+    /// while also allowing direct `handler.serve(transport)` style usage.
     pub async fn serve_handler<T, H>(
         signer: T,
         config: GatewayConfig,
@@ -97,9 +97,7 @@ impl NostrMCPGateway {
         use crate::NostrServerTransport;
         use rmcp::ServiceExt;
 
-        let transport = NostrServerTransport::new(signer, config.nostr_config)
-            .await?
-            .into_rmcp_transport();
+        let transport = NostrServerTransport::new(signer, config.nostr_config).await?;
         handler
             .serve(transport)
             .await

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -94,12 +94,14 @@ impl NostrMCPGateway {
         T: nostr_sdk::prelude::IntoNostrSigner,
         H: rmcp::ServerHandler,
     {
-        use crate::rmcp_transport::NostrServerWorker;
+        use crate::NostrServerTransport;
         use rmcp::ServiceExt;
 
-        let worker = NostrServerWorker::new(signer, config.nostr_config).await?;
+        let transport = NostrServerTransport::new(signer, config.nostr_config)
+            .await?
+            .into_rmcp_transport();
         handler
-            .serve(worker)
+            .serve(transport)
             .await
             .map_err(|e| Error::Other(format!("rmcp server initialization failed: {e}")))
     }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -73,7 +73,7 @@ impl NostrMCPProxy {
     /// Start a proxy directly from an rmcp client handler.
     ///
     /// This additive API keeps the existing `new/start/send` flow intact,
-    /// while allowing rmcp-first usage through the worker adapter.
+    /// while also allowing direct `handler.serve(transport)` style usage.
     pub async fn serve_client_handler<T, H>(
         signer: T,
         config: ProxyConfig,
@@ -86,9 +86,7 @@ impl NostrMCPProxy {
         use crate::NostrClientTransport;
         use rmcp::ServiceExt;
 
-        let transport = NostrClientTransport::new(signer, config.nostr_config)
-            .await?
-            .into_rmcp_transport();
+        let transport = NostrClientTransport::new(signer, config.nostr_config).await?;
         handler
             .serve(transport)
             .await

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -83,12 +83,14 @@ impl NostrMCPProxy {
         T: nostr_sdk::prelude::IntoNostrSigner,
         H: rmcp::ClientHandler,
     {
-        use crate::rmcp_transport::NostrClientWorker;
+        use crate::NostrClientTransport;
         use rmcp::ServiceExt;
 
-        let worker = NostrClientWorker::new(signer, config.nostr_config).await?;
+        let transport = NostrClientTransport::new(signer, config.nostr_config)
+            .await?
+            .into_rmcp_transport();
         handler
-            .serve(worker)
+            .serve(transport)
             .await
             .map_err(|e| Error::Other(format!("rmcp client initialization failed: {e}")))
     }

--- a/src/rmcp_transport/mod.rs
+++ b/src/rmcp_transport/mod.rs
@@ -3,6 +3,7 @@
 //! This module bridges the existing Nostr transport implementation with rmcp services.
 
 pub mod convert;
+pub mod transport;
 pub mod worker;
 
 #[cfg(test)]
@@ -12,4 +13,5 @@ pub use convert::{
     internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
     rmcp_server_tx_to_internal,
 };
+pub use transport::{NostrClientRmcpTransport, NostrServerRmcpTransport};
 pub use worker::{NostrClientWorker, NostrServerWorker};

--- a/src/rmcp_transport/mod.rs
+++ b/src/rmcp_transport/mod.rs
@@ -1,6 +1,7 @@
-//! RMCP integration scaffolding.
+//! rmcp integration for ContextVM Nostr transports.
 //!
-//! This module bridges the existing Nostr transport implementation with rmcp services.
+//! This module contains the conversion helpers and worker bridge that let raw
+//! ContextVM transports plug directly into rmcp service APIs.
 
 pub mod convert;
 pub mod transport;
@@ -13,5 +14,4 @@ pub use convert::{
     internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
     rmcp_server_tx_to_internal,
 };
-pub use transport::{NostrClientRmcpTransport, NostrServerRmcpTransport};
 pub use worker::{NostrClientWorker, NostrServerWorker};

--- a/src/rmcp_transport/transport.rs
+++ b/src/rmcp_transport/transport.rs
@@ -1,0 +1,55 @@
+//! Direct rmcp adapter entrypoints over raw ContextVM Nostr transports.
+
+use crate::{
+    core::error::Error,
+    rmcp_transport::worker::{NostrClientWorker, NostrServerWorker},
+    transport::{client::NostrClientTransport, server::NostrServerTransport},
+};
+
+/// Direct rmcp adapter for [`NostrServerTransport`](src/transport/server/mod.rs:87).
+pub struct NostrServerRmcpTransport {
+    worker: NostrServerWorker,
+}
+
+impl NostrServerTransport {
+    /// Convert this raw transport into an rmcp-compatible transport adapter.
+    pub fn into_rmcp_transport(self) -> NostrServerRmcpTransport {
+        NostrServerRmcpTransport {
+            worker: NostrServerWorker::from_transport(self),
+        }
+    }
+}
+
+impl rmcp::transport::IntoTransport<rmcp::RoleServer, Error, rmcp::transport::worker::WorkerAdapter>
+    for NostrServerRmcpTransport
+{
+    fn into_transport(
+        self,
+    ) -> impl rmcp::transport::Transport<rmcp::RoleServer, Error = Error> + 'static {
+        self.worker.into_transport()
+    }
+}
+
+/// Direct rmcp adapter for [`NostrClientTransport`](src/transport/client/mod.rs:69).
+pub struct NostrClientRmcpTransport {
+    worker: NostrClientWorker,
+}
+
+impl NostrClientTransport {
+    /// Convert this raw transport into an rmcp-compatible transport adapter.
+    pub fn into_rmcp_transport(self) -> NostrClientRmcpTransport {
+        NostrClientRmcpTransport {
+            worker: NostrClientWorker::from_transport(self),
+        }
+    }
+}
+
+impl rmcp::transport::IntoTransport<rmcp::RoleClient, Error, rmcp::transport::worker::WorkerAdapter>
+    for NostrClientRmcpTransport
+{
+    fn into_transport(
+        self,
+    ) -> impl rmcp::transport::Transport<rmcp::RoleClient, Error = Error> + 'static {
+        self.worker.into_transport()
+    }
+}

--- a/src/rmcp_transport/transport.rs
+++ b/src/rmcp_transport/transport.rs
@@ -1,4 +1,4 @@
-//! Direct rmcp adapter entrypoints over raw ContextVM Nostr transports.
+//! rmcp transport integration for raw ContextVM Nostr transports.
 
 use crate::{
     core::error::Error,
@@ -6,50 +6,26 @@ use crate::{
     transport::{client::NostrClientTransport, server::NostrServerTransport},
 };
 
-/// Direct rmcp adapter for [`NostrServerTransport`](src/transport/server/mod.rs:87).
-pub struct NostrServerRmcpTransport {
-    worker: NostrServerWorker,
-}
-
-impl NostrServerTransport {
-    /// Convert this raw transport into an rmcp-compatible transport adapter.
-    pub fn into_rmcp_transport(self) -> NostrServerRmcpTransport {
-        NostrServerRmcpTransport {
-            worker: NostrServerWorker::from_transport(self),
-        }
-    }
-}
-
 impl rmcp::transport::IntoTransport<rmcp::RoleServer, Error, rmcp::transport::worker::WorkerAdapter>
-    for NostrServerRmcpTransport
+    for NostrServerTransport
 {
+    /// Convert the raw server transport into rmcp's transport model via the
+    /// worker bridge.
     fn into_transport(
         self,
     ) -> impl rmcp::transport::Transport<rmcp::RoleServer, Error = Error> + 'static {
-        self.worker.into_transport()
-    }
-}
-
-/// Direct rmcp adapter for [`NostrClientTransport`](src/transport/client/mod.rs:69).
-pub struct NostrClientRmcpTransport {
-    worker: NostrClientWorker,
-}
-
-impl NostrClientTransport {
-    /// Convert this raw transport into an rmcp-compatible transport adapter.
-    pub fn into_rmcp_transport(self) -> NostrClientRmcpTransport {
-        NostrClientRmcpTransport {
-            worker: NostrClientWorker::from_transport(self),
-        }
+        NostrServerWorker::from_transport(self).into_transport()
     }
 }
 
 impl rmcp::transport::IntoTransport<rmcp::RoleClient, Error, rmcp::transport::worker::WorkerAdapter>
-    for NostrClientRmcpTransport
+    for NostrClientTransport
 {
+    /// Convert the raw client transport into rmcp's transport model via the
+    /// worker bridge.
     fn into_transport(
         self,
     ) -> impl rmcp::transport::Transport<rmcp::RoleClient, Error = Error> + 'static {
-        self.worker.into_transport()
+        NostrClientWorker::from_transport(self).into_transport()
     }
 }

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -39,6 +39,11 @@ impl NostrServerWorker {
         Ok(Self { transport })
     }
 
+    /// Create a worker from an already-constructed raw transport.
+    pub fn from_transport(transport: NostrServerTransport) -> Self {
+        Self { transport }
+    }
+
     /// Access the wrapped transport.
     pub fn transport(&self) -> &NostrServerTransport {
         &self.transport
@@ -155,6 +160,11 @@ impl NostrClientWorker {
     {
         let transport = NostrClientTransport::new(signer, config).await?;
         Ok(Self { transport })
+    }
+
+    /// Create a worker from an already-constructed raw transport.
+    pub fn from_transport(transport: NostrClientTransport) -> Self {
+        Self { transport }
     }
 
     /// Access the wrapped transport.


### PR DESCRIPTION
refactor(rmcp): add direct transport adapters for native ContextVM services

Introduce direct rmcp adapter entrypoints over the raw Nostr transports so
native ContextVM servers and clients can follow the expected transport-first
serve flow.

Changes:
- add direct rmcp adapters via [`NostrServerTransport::into_rmcp_transport()`](src/rmcp_transport/transport.rs:16) and [`NostrClientTransport::into_rmcp_transport()`](src/rmcp_transport/transport.rs:40)
- add [`NostrServerRmcpTransport`](src/rmcp_transport/transport.rs:10) and [`NostrClientRmcpTransport`](src/rmcp_transport/transport.rs:34)
- keep routing semantics stable by reusing the worker bridge through [`NostrServerWorker::from_transport()`](src/rmcp_transport/worker.rs:43) and [`NostrClientWorker::from_transport()`](src/rmcp_transport/worker.rs:166)
- rewire [`NostrMCPGateway::serve_handler()`](src/gateway/mod.rs:88) and [`NostrMCPProxy::serve_client_handler()`](src/proxy/mod.rs:77) to delegate to the new direct transport path
- update native echo examples in [`examples/native_echo_server.rs`](examples/native_echo_server.rs) and [`examples/native_echo_client.rs`](examples/native_echo_client.rs) to use direct transport serving
- update native transport docs in [`docs/server-transport.md`](docs/server-transport.md) and [`docs/client-transport.md`](docs/client-transport.md) to reflect the real API

Validation:
- full suite passed with [`cargo test --features rmcp`](Cargo.toml)
- direct relay flow validated with [`examples/native_echo_server.rs`](examples/native_echo_server.rs) and [`examples/native_echo_client.rs`](examples/native_echo_client.rs)

This flattens the public API around the raw transports while preserving the
existing event-id correlation and multi-client routing guarantees.
