### PR TITLE
fix: pre-release blockers for 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ tokio-util = { version = "0.7", features = ["rt"] }
 default = ["rmcp"]
 rmcp = ["dep:rmcp"]
 
+[[example]]
+name = "rmcp_integration_test"
+required-features = ["rmcp"]
+
 [dev-dependencies]
 tokio-test = "0.4"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -77,19 +77,16 @@ use contextvm_sdk::signer;
 async fn main() -> contextvm_sdk::Result<()> {
     let keys = signer::generate();
 
-    let config = GatewayConfig {
-        nostr_config: NostrServerTransportConfig {
-            relay_urls: vec!["wss://relay.damus.io".into()],
-            encryption_mode: EncryptionMode::Optional,
-            server_info: Some(ServerInfo {
-                name: Some("My MCP Server".into()),
-                about: Some("Tools via Nostr".into()),
-                ..Default::default()
-            }),
-            is_announced_server: true,
-            ..Default::default()
-        },
-    };
+    let config = GatewayConfig::new(
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_server_info(
+                ServerInfo::default()
+                    .with_name("My MCP Server")
+                    .with_about("Tools via Nostr"),
+            )
+            .with_announced_server(true),
+    );
 
     let mut gateway = NostrMCPGateway::new(keys, config).await?;
     let mut requests = gateway.start().await?;
@@ -116,14 +113,11 @@ use contextvm_sdk::signer;
 async fn main() -> contextvm_sdk::Result<()> {
     let keys = signer::generate();
 
-    let config = ProxyConfig {
-        nostr_config: NostrClientTransportConfig {
-            relay_urls: vec!["wss://relay.damus.io".into()],
-            server_pubkey: "abc123...server_hex_pubkey".into(),
-            encryption_mode: EncryptionMode::Optional,
-            ..Default::default()
-        },
-    };
+    let config = ProxyConfig::new(
+        NostrClientTransportConfig::default()
+            .with_server_pubkey("abc123...server_hex_pubkey")
+            .with_encryption_mode(EncryptionMode::Optional),
+    );
 
     let mut proxy = NostrMCPProxy::new(keys, config).await?;
     let mut responses = proxy.start().await?;

--- a/examples/gateway.rs
+++ b/examples/gateway.rs
@@ -37,19 +37,17 @@ async fn main() -> contextvm_sdk::Result<()> {
     println!("Server pubkey: {}", keys.public_key().to_hex());
 
     // Configure the gateway
-    let config = GatewayConfig {
-        nostr_config: NostrServerTransportConfig {
-            relay_urls: vec!["wss://relay.damus.io".to_string()],
-            server_info: Some(ServerInfo {
-                name: Some("Echo Server".to_string()),
-                about: Some("A simple echo tool exposed via ContextVM".to_string()),
-                ..Default::default()
-            }),
-            is_announced_server: true,
-            log_file_path,
-            ..Default::default()
-        },
-    };
+    let mut nostr_config = NostrServerTransportConfig::default()
+        .with_server_info(
+            ServerInfo::default()
+                .with_name("Echo Server")
+                .with_about("A simple echo tool exposed via ContextVM"),
+        )
+        .with_announced_server(true);
+    if let Some(path) = log_file_path {
+        nostr_config = nostr_config.with_log_file_path(path);
+    }
+    let config = GatewayConfig::new(nostr_config);
 
     let mut gateway = NostrMCPGateway::new(keys, config).await?;
     let mut rx = gateway.start().await?;

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -41,15 +41,13 @@ async fn main() -> contextvm_sdk::Result<()> {
     let keys = signer::generate();
     println!("Client pubkey: {}", keys.public_key().to_hex());
 
-    let config = ProxyConfig {
-        nostr_config: NostrClientTransportConfig {
-            relay_urls: vec!["wss://relay.damus.io".to_string()],
-            server_pubkey: server_pubkey_hex,
-            encryption_mode: EncryptionMode::Optional,
-            log_file_path,
-            ..Default::default()
-        },
-    };
+    let mut nostr_config = NostrClientTransportConfig::default()
+        .with_server_pubkey(server_pubkey_hex)
+        .with_encryption_mode(EncryptionMode::Optional);
+    if let Some(path) = log_file_path {
+        nostr_config = nostr_config.with_log_file_path(path);
+    }
+    let config = ProxyConfig::new(nostr_config);
 
     let mut proxy = NostrMCPProxy::new(keys, config).await?;
     let mut rx = proxy.start().await?;

--- a/examples/rmcp_integration_test.rs
+++ b/examples/rmcp_integration_test.rs
@@ -571,30 +571,24 @@ async fn run_relay_rmcp_case(relay_url: &str) -> Result<()> {
 }
 
 fn server_config(relay_url: &str) -> GatewayConfig {
-    GatewayConfig {
-        nostr_config: NostrServerTransportConfig {
-            relay_urls: vec![relay_url.to_string()],
-            encryption_mode: EncryptionMode::Optional,
-            server_info: Some(CtxServerInfo {
-                name: Some("rmcp-matrix-server".to_string()),
-                about: Some("rmcp matrix coverage server".to_string()),
-                ..Default::default()
-            }),
-            is_announced_server: false,
-            ..Default::default()
-        },
-    }
+    let nostr_config = NostrServerTransportConfig::default()
+        .with_relay_urls(vec![relay_url.to_string()])
+        .with_encryption_mode(EncryptionMode::Optional)
+        .with_server_info(
+            CtxServerInfo::default()
+                .with_name("rmcp-matrix-server")
+                .with_about("rmcp matrix coverage server"),
+        )
+        .with_announced_server(false);
+    GatewayConfig::new(nostr_config)
 }
 
 fn client_config(relay_url: &str, server_pubkey: String) -> ProxyConfig {
-    ProxyConfig {
-        nostr_config: NostrClientTransportConfig {
-            relay_urls: vec![relay_url.to_string()],
-            server_pubkey,
-            encryption_mode: EncryptionMode::Optional,
-            ..Default::default()
-        },
-    }
+    let nostr_config = NostrClientTransportConfig::default()
+        .with_relay_urls(vec![relay_url.to_string()])
+        .with_server_pubkey(server_pubkey)
+        .with_encryption_mode(EncryptionMode::Optional);
+    ProxyConfig::new(nostr_config)
 }
 
 async fn send_legacy_request_and_wait(

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -64,6 +64,7 @@ impl GiftWrapMode {
 /// Published as the content of a replaceable Nostr event so that clients
 /// can discover the server's identity and metadata.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ServerInfo {
     /// Human-readable server name.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,6 +81,34 @@ pub struct ServerInfo {
     /// Short description of the server's purpose.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub about: Option<String>,
+}
+
+impl ServerInfo {
+    /// Set the server name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+    /// Set the server version.
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+    /// Set the server picture URL.
+    pub fn with_picture(mut self, picture: impl Into<String>) -> Self {
+        self.picture = Some(picture.into());
+        self
+    }
+    /// Set the server website URL.
+    pub fn with_website(mut self, website: impl Into<String>) -> Self {
+        self.website = Some(website.into());
+        self
+    }
+    /// Set the server description.
+    pub fn with_about(mut self, about: impl Into<String>) -> Self {
+        self.about = Some(about.into());
+        self
+    }
 }
 
 // ── Client session ──────────────────────────────────────────────────

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -8,9 +8,17 @@ use crate::core::types::JsonRpcMessage;
 use crate::transport::server::{IncomingRequest, NostrServerTransport, NostrServerTransportConfig};
 
 /// Configuration for the gateway.
+#[non_exhaustive]
 pub struct GatewayConfig {
     /// Nostr server transport configuration.
     pub nostr_config: NostrServerTransportConfig,
+}
+
+impl GatewayConfig {
+    /// Create a new gateway configuration.
+    pub fn new(nostr_config: NostrServerTransportConfig) -> Self {
+        Self { nostr_config }
+    }
 }
 
 /// Gateway that bridges a local MCP server to Nostr.

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -8,9 +8,17 @@ use crate::core::types::JsonRpcMessage;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 
 /// Configuration for the proxy.
+#[non_exhaustive]
 pub struct ProxyConfig {
     /// Nostr client transport configuration.
     pub nostr_config: NostrClientTransportConfig,
+}
+
+impl ProxyConfig {
+    /// Create a new proxy configuration.
+    pub fn new(nostr_config: NostrClientTransportConfig) -> Self {
+        Self { nostr_config }
+    }
 }
 
 /// Proxy that connects to a remote MCP server via Nostr.

--- a/src/transport/client/correlation_store.rs
+++ b/src/transport/client/correlation_store.rs
@@ -45,7 +45,7 @@ impl ClientCorrelationStore {
     pub fn with_max_pending(max_pending: usize) -> Self {
         Self {
             pending_requests: Arc::new(RwLock::new(LruCache::new(
-                NonZeroUsize::new(max_pending).expect("max_pending must be non-zero"),
+                NonZeroUsize::new(max_pending).unwrap_or(NonZeroUsize::new(1).unwrap()),
             ))),
         }
     }

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -31,6 +31,7 @@ use crate::util::tracing_setup;
 const LOG_TARGET: &str = "contextvm_sdk::transport::client";
 
 /// Configuration for the client transport.
+#[non_exhaustive]
 pub struct NostrClientTransportConfig {
     /// Relay URLs to connect to.
     pub relay_urls: Vec<String>,
@@ -63,6 +64,44 @@ impl Default for NostrClientTransportConfig {
             timeout: Duration::from_secs(30),
             log_file_path: None,
         }
+    }
+}
+
+impl NostrClientTransportConfig {
+    /// Set the server's public key (hex).
+    pub fn with_server_pubkey(mut self, pubkey: impl Into<String>) -> Self {
+        self.server_pubkey = pubkey.into();
+        self
+    }
+    /// Set the encryption mode.
+    pub fn with_encryption_mode(mut self, mode: EncryptionMode) -> Self {
+        self.encryption_mode = mode;
+        self
+    }
+    /// Set the gift-wrap mode (CEP-19).
+    pub fn with_gift_wrap_mode(mut self, mode: GiftWrapMode) -> Self {
+        self.gift_wrap_mode = mode;
+        self
+    }
+    /// Enable or disable stateless mode.
+    pub fn with_stateless(mut self, stateless: bool) -> Self {
+        self.is_stateless = stateless;
+        self
+    }
+    /// Set the relay URLs to connect to.
+    pub fn with_relay_urls(mut self, urls: Vec<String>) -> Self {
+        self.relay_urls = urls;
+        self
+    }
+    /// Set the correlation-retention TTL.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+    /// Set the log file path.
+    pub fn with_log_file_path(mut self, path: impl Into<String>) -> Self {
+        self.log_file_path = Some(path.into());
+        self
     }
 }
 
@@ -442,7 +481,15 @@ impl NostrClientTransport {
                 result = notifications.recv() => {
                     let notification = match result {
                         Ok(n) => n,
-                        Err(_) => break,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                target: LOG_TARGET,
+                                skipped = n,
+                                "Relay broadcast lagged, skipping missed events"
+                            );
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     };
                     Self::handle_notification(
                         &notification,

--- a/src/transport/server/correlation_store.rs
+++ b/src/transport/server/correlation_store.rs
@@ -39,7 +39,7 @@ struct Inner {
 impl Inner {
     fn new(max_routes: usize) -> Self {
         let routes =
-            LruCache::new(NonZeroUsize::new(max_routes).expect("max_routes must be non-zero"));
+            LruCache::new(NonZeroUsize::new(max_routes).unwrap_or(NonZeroUsize::new(1).unwrap()));
         Self {
             routes,
             progress_token_to_event: HashMap::new(),

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -34,6 +34,7 @@ use crate::util::tracing_setup;
 const LOG_TARGET: &str = "contextvm_sdk::transport::server";
 
 /// Configuration for the server transport.
+#[non_exhaustive]
 pub struct NostrServerTransportConfig {
     /// Relay URLs to connect to.
     pub relay_urls: Vec<String>,
@@ -113,8 +114,72 @@ pub struct NostrServerTransport {
     task_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
+impl NostrServerTransportConfig {
+    /// Set the encryption mode.
+    pub fn with_encryption_mode(mut self, mode: EncryptionMode) -> Self {
+        self.encryption_mode = mode;
+        self
+    }
+    /// Set the gift-wrap mode (CEP-19).
+    pub fn with_gift_wrap_mode(mut self, mode: GiftWrapMode) -> Self {
+        self.gift_wrap_mode = mode;
+        self
+    }
+    /// Set server information for announcements.
+    pub fn with_server_info(mut self, info: ServerInfo) -> Self {
+        self.server_info = Some(info);
+        self
+    }
+    /// Enable or disable public announcement publishing (CEP-6).
+    pub fn with_announced_server(mut self, announced: bool) -> Self {
+        self.is_announced_server = announced;
+        self
+    }
+    /// Set the allowed client public keys (hex). Empty = allow all.
+    pub fn with_allowed_public_keys(mut self, keys: Vec<String>) -> Self {
+        self.allowed_public_keys = keys;
+        self
+    }
+    /// Set capabilities excluded from pubkey whitelisting.
+    pub fn with_excluded_capabilities(mut self, caps: Vec<CapabilityExclusion>) -> Self {
+        self.excluded_capabilities = caps;
+        self
+    }
+    /// Set the maximum number of concurrent client sessions.
+    pub fn with_max_sessions(mut self, max: usize) -> Self {
+        self.max_sessions = max;
+        self
+    }
+    /// Set the relay URLs to connect to.
+    pub fn with_relay_urls(mut self, urls: Vec<String>) -> Self {
+        self.relay_urls = urls;
+        self
+    }
+    /// Set the session cleanup interval.
+    pub fn with_cleanup_interval(mut self, interval: Duration) -> Self {
+        self.cleanup_interval = interval;
+        self
+    }
+    /// Set the session timeout.
+    pub fn with_session_timeout(mut self, timeout: Duration) -> Self {
+        self.session_timeout = timeout;
+        self
+    }
+    /// Set the correlation-retention TTL for event routes.
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+    /// Set the log file path.
+    pub fn with_log_file_path(mut self, path: impl Into<String>) -> Self {
+        self.log_file_path = Some(path.into());
+        self
+    }
+}
+
 /// An incoming MCP request with metadata for routing the response.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct IncomingRequest {
     /// The parsed MCP message.
     pub message: JsonRpcMessage,
@@ -899,7 +964,15 @@ impl NostrServerTransport {
                 result = notifications.recv() => {
                     match result {
                         Ok(n) => n,
-                        Err(_) => break,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                target: LOG_TARGET,
+                                skipped = n,
+                                "Relay broadcast lagged, skipping missed events"
+                            );
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     }
                 }
             };

--- a/src/transport/server/session_store.rs
+++ b/src/transport/server/session_store.rs
@@ -53,7 +53,7 @@ impl SessionStore {
     pub fn with_capacity(max_sessions: usize) -> Self {
         Self {
             sessions: Arc::new(RwLock::new(LruCache::new(
-                NonZeroUsize::new(max_sessions).expect("max_sessions must be > 0"),
+                NonZeroUsize::new(max_sessions).unwrap_or(NonZeroUsize::new(1).unwrap()),
             ))),
             on_evicted: None,
         }

--- a/tests/conformance_stateless_mode.rs
+++ b/tests/conformance_stateless_mode.rs
@@ -17,15 +17,13 @@ async fn make_stateless_transport() -> (
     let server_keys = signer::generate();
     let client_keys = signer::generate();
 
-    let config = NostrClientTransportConfig {
-        relay_urls: Vec::new(),
-        server_pubkey: server_keys.public_key().to_hex(),
-        encryption_mode: EncryptionMode::Optional,
-        gift_wrap_mode: GiftWrapMode::Optional,
-        is_stateless: true,
-        timeout: Duration::from_secs(1),
-        log_file_path: None,
-    };
+    let config = NostrClientTransportConfig::default()
+        .with_relay_urls(Vec::new())
+        .with_server_pubkey(server_keys.public_key().to_hex())
+        .with_encryption_mode(EncryptionMode::Optional)
+        .with_gift_wrap_mode(GiftWrapMode::Optional)
+        .with_stateless(true)
+        .with_timeout(Duration::from_secs(1));
 
     let mut transport = NostrClientTransport::new(client_keys, config)
         .await

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -136,21 +136,16 @@ async fn full_initialization_handshake() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -227,15 +222,10 @@ async fn server_announcement_publishing() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            is_announced_server: true,
-            server_info: Some(ServerInfo {
-                name: Some("Phase3-Test-Server".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_server_info(ServerInfo::default().with_name("Phase3-Test-Server".to_string()))
+            .with_announced_server(true),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -273,10 +263,7 @@ async fn encryption_mode_optional_accepts_plaintext() {
 
     // Server uses Optional — should accept both encrypted and plaintext.
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Optional),
         as_pool(server_pool),
     )
     .await
@@ -289,11 +276,9 @@ async fn encryption_mode_optional_accepts_plaintext() {
 
     // Client uses Disabled — sends plaintext kind 25910.
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -337,11 +322,9 @@ async fn auth_allowlist_blocks_disallowed_pubkey() {
 
     // Server allows only `allowed_keys` — client_keys is NOT allowed.
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_allowed_public_keys(vec![allowed_keys.public_key().to_hex()]),
         as_pool(server_pool),
     )
     .await
@@ -353,11 +336,9 @@ async fn auth_allowlist_blocks_disallowed_pubkey() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -392,10 +373,7 @@ async fn encryption_mode_required_drops_plaintext() {
 
     // Server requires encryption — plaintext must be dropped.
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Required),
         as_pool(server_pool),
     )
     .await
@@ -408,11 +386,9 @@ async fn encryption_mode_required_drops_plaintext() {
 
     // Client sends plaintext (Disabled mode).
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -446,21 +422,16 @@ async fn encrypted_gift_wrap_roundtrip() {
     let server_pool = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Required),
         Arc::clone(&server_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
     )
     .await
@@ -534,21 +505,16 @@ async fn gift_wrap_dedup_skips_duplicate_delivery() {
     let server_pool = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Required),
         Arc::clone(&server_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
     )
     .await
@@ -608,21 +574,16 @@ async fn correlated_notification_has_e_tag() {
     let server_pool = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&server_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -707,21 +668,16 @@ async fn encryption_required_client_optional_server() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Optional),
         as_pool(server_pool),
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
     )
     .await
@@ -769,21 +725,16 @@ async fn encryption_optional_both_sides_encrypted_path() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Optional),
         as_pool(server_pool),
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Optional,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Optional),
         as_pool(client_pool),
     )
     .await
@@ -824,15 +775,10 @@ async fn announce_includes_encryption_tags() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            is_announced_server: true,
-            server_info: Some(ServerInfo {
-                name: Some("Encrypted-Server".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Required)
+            .with_server_info(ServerInfo::default().with_name("Encrypted-Server".to_string()))
+            .with_announced_server(true),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -873,18 +819,16 @@ async fn announce_includes_server_metadata_tags() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            is_announced_server: true,
-            server_info: Some(ServerInfo {
-                name: Some("Meta-Server".to_string()),
-                about: Some("A test server".to_string()),
-                website: Some("https://example.com".to_string()),
-                picture: Some("https://example.com/pic.png".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_server_info(
+                ServerInfo::default()
+                    .with_name("Meta-Server".to_string())
+                    .with_about("A test server".to_string())
+                    .with_website("https://example.com".to_string())
+                    .with_picture("https://example.com/pic.png".to_string()),
+            )
+            .with_announced_server(true),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -935,15 +879,10 @@ async fn publish_tools_produces_correct_kind() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            is_announced_server: true,
-            server_info: Some(ServerInfo {
-                name: Some("Tools-Server".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_server_info(ServerInfo::default().with_name("Tools-Server".to_string()))
+            .with_announced_server(true),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -984,10 +923,7 @@ async fn broadcast_notification_reaches_initialized_client() {
     let server_pk = s_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(s_pool),
     )
     .await
@@ -999,11 +935,9 @@ async fn broadcast_notification_reaches_initialized_client() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pk.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pk.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(c1_pool),
     )
     .await
@@ -1106,21 +1040,16 @@ async fn uncorrelated_notification_passes_through() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -1204,21 +1133,16 @@ async fn correlated_notification_unknown_e_tag_is_dropped() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -1299,11 +1223,9 @@ async fn auth_allowed_pubkey_receives_response() {
     let client_pubkey = client_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            allowed_public_keys: vec![client_pubkey.to_hex()],
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_allowed_public_keys(vec![client_pubkey.to_hex()]),
         as_pool(server_pool),
     )
     .await
@@ -1315,11 +1237,9 @@ async fn auth_allowed_pubkey_receives_response() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -1378,15 +1298,13 @@ async fn excluded_capability_bypasses_auth() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
-            excluded_capabilities: vec![CapabilityExclusion {
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_allowed_public_keys(vec![allowed_keys.public_key().to_hex()])
+            .with_excluded_capabilities(vec![CapabilityExclusion {
                 method: "tools/list".to_string(),
                 name: None,
-            }],
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+            }]),
         as_pool(server_pool),
     )
     .await
@@ -1398,11 +1316,9 @@ async fn excluded_capability_bypasses_auth() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -1440,10 +1356,7 @@ async fn publish_resources_produces_correct_kind() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -1483,10 +1396,7 @@ async fn publish_prompts_produces_correct_kind() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -1525,10 +1435,7 @@ async fn publish_resource_templates_produces_correct_kind() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -1568,10 +1475,7 @@ async fn publish_tools_empty_list() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -1602,15 +1506,10 @@ async fn delete_announcements_k_tags_match_kinds() {
     let pool = Arc::new(MockRelayPool::new());
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            is_announced_server: true,
-            server_info: Some(ServerInfo {
-                name: Some("KTag-Server".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_server_info(ServerInfo::default().with_name("KTag-Server".to_string()))
+            .with_announced_server(true),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -1665,10 +1564,7 @@ async fn encryption_disabled_server_rejects_gift_wrap() {
 
     // Server has encryption disabled — must reject gift-wrap events.
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await
@@ -1681,11 +1577,9 @@ async fn encryption_disabled_server_rejects_gift_wrap() {
 
     // Client requires encryption — sends gift-wrap (kind 1059).
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Required,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
     )
     .await
@@ -1720,21 +1614,16 @@ async fn response_mirrors_client_encryption_format() {
         let server_pool = Arc::new(server_pool);
 
         let mut server = NostrServerTransport::with_relay_pool(
-            NostrServerTransportConfig {
-                encryption_mode: EncryptionMode::Optional,
-                ..Default::default()
-            },
+            NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Optional),
             Arc::clone(&server_pool) as Arc<dyn RelayPoolTrait>,
         )
         .await
         .expect("create server transport");
 
         let mut client = NostrClientTransport::with_relay_pool(
-            NostrClientTransportConfig {
-                server_pubkey: server_pubkey.to_hex(),
-                encryption_mode: EncryptionMode::Disabled,
-                ..Default::default()
-            },
+            NostrClientTransportConfig::default()
+                .with_server_pubkey(server_pubkey.to_hex())
+                .with_encryption_mode(EncryptionMode::Disabled),
             as_pool(client_pool),
         )
         .await
@@ -1807,21 +1696,16 @@ async fn response_mirrors_client_encryption_format() {
         let server_pool = Arc::new(server_pool);
 
         let mut server = NostrServerTransport::with_relay_pool(
-            NostrServerTransportConfig {
-                encryption_mode: EncryptionMode::Optional,
-                ..Default::default()
-            },
+            NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Optional),
             Arc::clone(&server_pool) as Arc<dyn RelayPoolTrait>,
         )
         .await
         .expect("create server transport");
 
         let mut client = NostrClientTransport::with_relay_pool(
-            NostrClientTransportConfig {
-                server_pubkey: server_pubkey.to_hex(),
-                encryption_mode: EncryptionMode::Required,
-                ..Default::default()
-            },
+            NostrClientTransportConfig::default()
+                .with_server_pubkey(server_pubkey.to_hex())
+                .with_encryption_mode(EncryptionMode::Required),
             as_pool(client_pool),
         )
         .await
@@ -1908,21 +1792,16 @@ async fn send_response_is_one_shot_under_concurrency() {
     ));
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         delayed_server_pool,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2010,21 +1889,16 @@ async fn send_response_publish_failure_allows_one_successful_retry() {
     ));
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&failing_server_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2132,12 +2006,10 @@ async fn announced_server_sends_unauthorized_error_response() {
 
     // Announced server with an allowlist that does NOT include the client.
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
-            is_announced_server: true,
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_announced_server(true)
+            .with_allowed_public_keys(vec![allowed_keys.public_key().to_hex()]),
         as_pool(server_pool),
     )
     .await
@@ -2149,11 +2021,9 @@ async fn announced_server_sends_unauthorized_error_response() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2212,11 +2082,9 @@ async fn private_server_silently_drops_unauthorized_request() {
 
     // Private server (is_announced_server defaults to false).
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_allowed_public_keys(vec![allowed_keys.public_key().to_hex()]),
         as_pool(server_pool),
     )
     .await
@@ -2228,11 +2096,9 @@ async fn private_server_silently_drops_unauthorized_request() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2276,12 +2142,10 @@ async fn announced_server_does_not_error_on_unauthorized_notification() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            allowed_public_keys: vec![allowed_keys.public_key().to_hex()],
-            is_announced_server: true,
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_announced_server(true)
+            .with_allowed_public_keys(vec![allowed_keys.public_key().to_hex()]),
         as_pool(server_pool),
     )
     .await
@@ -2293,11 +2157,9 @@ async fn announced_server_does_not_error_on_unauthorized_notification() {
     server.start().await.expect("server start");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2341,27 +2203,20 @@ async fn first_response_includes_discovery_tags() {
     let s_pool = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            is_announced_server: true,
-            server_info: Some(ServerInfo {
-                name: Some("Disco-Server".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Optional)
+            .with_server_info(ServerInfo::default().with_name("Disco-Server".to_string()))
+            .with_announced_server(true),
         Arc::clone(&s_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2472,23 +2327,19 @@ async fn notification_mirror_selection_wrt_cep_19() {
     let s_pool = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Optional),
         Arc::clone(&s_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .expect("create server transport");
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Ephemeral,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Ephemeral),
         as_pool(client_pool),
     )
     .await
@@ -2561,22 +2412,18 @@ async fn server_response_includes_encryption_tags_when_enabled() {
     let server_pool_arc = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Optional),
         Arc::clone(&server_pool_arc) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2639,22 +2486,18 @@ async fn server_response_excludes_ephemeral_tag_when_persistent() {
     let server_pool_arc = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Persistent,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Persistent),
         Arc::clone(&server_pool_arc) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2716,21 +2559,16 @@ async fn server_learns_capabilities_from_client_request() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2781,25 +2619,18 @@ async fn server_disabled_encryption_omits_encryption_tags() {
     let server_pool_arc = Arc::new(server_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            server_info: Some(ServerInfo {
-                name: Some("NoEncrypt".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_server_info(ServerInfo::default().with_name("NoEncrypt".to_string())),
         Arc::clone(&server_pool_arc) as Arc<dyn RelayPoolTrait>,
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -2866,12 +2697,10 @@ async fn client_disabled_encryption_emits_no_discovery_tags() {
     let server_keys = Keys::generate();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_keys.public_key().to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_keys.public_key().to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_gift_wrap_mode(GiftWrapMode::Optional),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -2915,12 +2744,10 @@ async fn client_second_request_carries_no_discovery_tags() {
     let server_keys = Keys::generate();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_keys.public_key().to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_keys.public_key().to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled)
+            .with_gift_wrap_mode(GiftWrapMode::Optional),
         Arc::clone(&pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -2975,26 +2802,19 @@ async fn client_learns_server_capabilities_from_first_response() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            server_info: Some(ServerInfo {
-                name: Some("CapServer".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Optional)
+            .with_server_info(ServerInfo::default().with_name("CapServer".to_string())),
         as_pool(server_pool),
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -3067,26 +2887,19 @@ async fn client_or_assigns_capabilities_across_responses() {
     let client_pool = Arc::new(client_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            server_info: Some(ServerInfo {
-                name: Some("PersistentServer".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Persistent,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Persistent)
+            .with_server_info(ServerInfo::default().with_name("PersistentServer".to_string())),
         as_pool(server_pool),
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&client_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -3186,26 +2999,19 @@ async fn client_baseline_event_not_replaced_by_later_responses() {
     let client_pool = Arc::new(client_pool);
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            server_info: Some(ServerInfo {
-                name: Some("BaselineServer".to_string()),
-                ..Default::default()
-            }),
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default()
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Optional)
+            .with_server_info(ServerInfo::default().with_name("BaselineServer".to_string())),
         as_pool(server_pool),
     )
     .await
     .unwrap();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&client_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -3296,12 +3102,10 @@ async fn client_optional_encryption_emits_discovery_tags() {
     let client_pool = Arc::new(client_pool);
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Optional,
-            gift_wrap_mode: GiftWrapMode::Optional,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_gift_wrap_mode(GiftWrapMode::Optional),
         Arc::clone(&client_pool) as Arc<dyn RelayPoolTrait>,
     )
     .await
@@ -3361,32 +3165,25 @@ async fn multi_client_concurrent_requests_both_get_responses() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await
     .expect("create server transport");
 
     let mut client_a = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_a_pool),
     )
     .await
     .expect("create client A");
 
     let mut client_b = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_b_pool),
     )
     .await
@@ -3532,11 +3329,9 @@ async fn client_close_stops_event_loop() {
     let server_pubkey = server_pool.mock_public_key();
 
     let mut client = NostrClientTransport::with_relay_pool(
-        NostrClientTransportConfig {
-            server_pubkey: server_pubkey.to_hex(),
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrClientTransportConfig::default()
+            .with_server_pubkey(server_pubkey.to_hex())
+            .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
     )
     .await
@@ -3562,10 +3357,7 @@ async fn server_close_stops_event_loop() {
     let (_client_pool, server_pool) = MockRelayPool::create_pair();
 
     let mut server = NostrServerTransport::with_relay_pool(
-        NostrServerTransportConfig {
-            encryption_mode: EncryptionMode::Disabled,
-            ..Default::default()
-        },
+        NostrServerTransportConfig::default().with_encryption_mode(EncryptionMode::Disabled),
         as_pool(server_pool),
     )
     .await


### PR DESCRIPTION
Closes #65 

Fixes all blockers identified in #65 

What changed:

Added #[non_exhaustive] to all public config and data structs (NostrServerTransportConfig, NostrClientTransportConfig, GatewayConfig, ProxyConfig, IncomingRequest, ServerInfo). Without this, adding any new field in 0.2.0 would silently break users constructing configs with struct literals. Added builder methods for every field so the API stays ergonomic.

Fixed RecvError::Lagged in both client and server event loops. Previously any broadcast error killed the event loop silently - including Lagged which is fully recoverable. Now Lagged logs a warning and continues, only Closed exits the loop.

Clamped zero-capacity config values to 1 instead of panicking. SessionStore::with_capacity(0), ClientCorrelationStore::with_max_pending(0), and ServerEventRouteStore::with_max_routes(0) were all reachable via 
public config fields and would hit NonZeroUsize::new(0).expect().

Fixed cargo test --no-default-features by adding required-features = ["rmcp"] to rmcp_integration_test in Cargo.toml - was failing with 37 compile errors before this change.

Also updated README examples and test files to use the new builder pattern.

