### PR TITLE
fix(rmcp): bridge stateless CEP-35 requests into rmcp lifecycle

### DIFF
--- a/src/rmcp_transport/pipeline_tests.rs
+++ b/src/rmcp_transport/pipeline_tests.rs
@@ -14,18 +14,87 @@
 
 #[cfg(all(test, feature = "rmcp"))]
 mod tests {
+    use std::sync::Arc;
+
     use rmcp::model::{
-        ClientJsonRpcMessage, ClientResult, RequestId, ServerJsonRpcMessage, ServerResult,
+        CallToolRequestParams, CallToolResult, ClientJsonRpcMessage, ClientResult, ErrorData,
+        Implementation, ProtocolVersion, RequestId, ServerCapabilities, ServerInfo,
+        ServerJsonRpcMessage, ServerResult,
+    };
+    use rmcp::{
+        handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+        schemars, tool, tool_handler, tool_router, ClientHandler, ServerHandler, ServiceExt,
     };
 
     use crate::core::serializers;
+    use crate::core::types::{EncryptionMode, GiftWrapMode};
     use crate::core::types::{
         JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
     };
+    use crate::relay::mock::MockRelayPool;
+    use crate::relay::RelayPoolTrait;
     use crate::rmcp_transport::convert::{
         internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
         rmcp_server_tx_to_internal,
     };
+    use crate::transport::{
+        client::{NostrClientTransport, NostrClientTransportConfig},
+        server::{NostrServerTransport, NostrServerTransportConfig},
+    };
+
+    #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+    struct EchoParams {
+        message: String,
+    }
+
+    #[derive(Clone)]
+    struct StatelessTestServer {
+        tool_router: ToolRouter<Self>,
+    }
+
+    impl StatelessTestServer {
+        fn new() -> Self {
+            Self {
+                tool_router: Self::tool_router(),
+            }
+        }
+    }
+
+    #[tool_router]
+    impl StatelessTestServer {
+        #[tool(description = "Echo a message back unchanged")]
+        async fn echo(
+            &self,
+            Parameters(EchoParams { message }): Parameters<EchoParams>,
+        ) -> Result<CallToolResult, ErrorData> {
+            Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                format!("Echo: {message}"),
+            )]))
+        }
+    }
+
+    #[tool_handler]
+    impl ServerHandler for StatelessTestServer {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo {
+                protocol_version: ProtocolVersion::LATEST,
+                capabilities: ServerCapabilities::builder().enable_tools().build(),
+                server_info: Implementation {
+                    name: "stateless-test-server".to_string(),
+                    title: Some("Stateless Test Server".to_string()),
+                    version: "0.1.0".to_string(),
+                    description: Some("Stateless rmcp regression test server".to_string()),
+                    icons: None,
+                    website_url: None,
+                },
+                instructions: Some("Use the echo tool".to_string()),
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct StatelessTestClient;
+    impl ClientHandler for StatelessTestClient {}
 
     // ── Layer 1: Nostr event content → JsonRpcMessage ──────────────────────
 
@@ -322,6 +391,93 @@ mod tests {
             }
             other => panic!("expected ErrorResponse, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn stateless_rmcp_roundtrip_over_mock_relay_preserves_correlation() {
+        let (server_pool, client_pool) = MockRelayPool::create_pair();
+        let server_pubkey = server_pool
+            .public_key()
+            .await
+            .expect("server mock relay pubkey")
+            .to_hex();
+
+        let server_transport = NostrServerTransport::with_relay_pool(
+            NostrServerTransportConfig::default()
+                .with_relay_urls(vec!["mock://relay".to_string()])
+                .with_encryption_mode(EncryptionMode::Disabled)
+                .with_gift_wrap_mode(GiftWrapMode::Optional),
+            Arc::new(server_pool),
+        )
+        .await
+        .expect("server transport");
+
+        let server_task = tokio::spawn(async move {
+            StatelessTestServer::new()
+                .serve(server_transport)
+                .await
+                .expect("server should start")
+                .waiting()
+                .await
+                .expect("server should keep running until aborted");
+        });
+
+        let client_transport = NostrClientTransport::with_relay_pool(
+            NostrClientTransportConfig::default()
+                .with_relay_urls(vec!["mock://relay".to_string()])
+                .with_server_pubkey(server_pubkey)
+                .with_encryption_mode(EncryptionMode::Disabled)
+                .with_gift_wrap_mode(GiftWrapMode::Optional)
+                .with_stateless(true),
+            Arc::new(client_pool),
+        )
+        .await
+        .expect("client transport");
+
+        let client = StatelessTestClient
+            .serve(client_transport)
+            .await
+            .expect("stateless client should start");
+
+        let peer_info = client
+            .peer_info()
+            .expect("peer info from emulated initialize");
+        assert_eq!(peer_info.server_info.name, "Emulated-Stateless-Server");
+
+        let tools = client
+            .list_all_tools()
+            .await
+            .expect("tools/list should succeed");
+        assert!(
+            tools.iter().any(|tool| tool.name == "echo"),
+            "expected echo tool from server"
+        );
+
+        let result = client
+            .call_tool(CallToolRequestParams {
+                name: "echo".into(),
+                arguments: serde_json::from_value(serde_json::json!({
+                    "message": "hello from stateless test"
+                }))
+                .ok(),
+                meta: None,
+                task: None,
+            })
+            .await
+            .expect("tools/call should succeed");
+
+        let echoed = result
+            .content
+            .iter()
+            .find_map(|content| match &content.raw {
+                rmcp::model::RawContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            })
+            .expect("echo response text");
+        assert_eq!(echoed, "Echo: hello from stateless test");
+
+        client.cancel().await.expect("client cancel");
+        server_task.abort();
     }
 
     // ── Helper ──────────────────────────────────────────────────────────────

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -4,10 +4,11 @@
 //! transports to rmcp's worker abstraction.
 
 use crate::core::error::Result;
-use crate::core::types::JsonRpcMessage;
+use crate::core::types::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest};
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 use crate::transport::server::{NostrServerTransport, NostrServerTransportConfig};
 use rmcp::transport::worker::{Worker, WorkerContext, WorkerQuitReason};
+use std::collections::HashSet;
 
 use super::convert::{
     internal_to_rmcp_client_rx, internal_to_rmcp_server_rx, rmcp_client_tx_to_internal,
@@ -16,6 +17,51 @@ use super::convert::{
 
 const LOG_TARGET: &str = "contextvm_sdk::rmcp_transport::worker";
 const STATELESS_SYNTHETIC_EVENT_ID: &str = "contextvm-stateless-init";
+
+fn synthetic_initialize_message() -> JsonRpcMessage {
+    JsonRpcMessage::Request(JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID),
+        method: "initialize".to_string(),
+        params: Some(serde_json::json!({
+            "protocolVersion": crate::core::constants::mcp_protocol_version(),
+            "capabilities": {},
+            "clientInfo": {
+                "name": "contextvm-stateless-client",
+                "version": "0.1.0"
+            }
+        })),
+    })
+}
+
+fn synthetic_initialized_notification() -> JsonRpcMessage {
+    JsonRpcMessage::Notification(JsonRpcNotification {
+        jsonrpc: "2.0".to_string(),
+        method: "notifications/initialized".to_string(),
+        params: None,
+    })
+}
+
+fn should_inject_stateless_bootstrap(
+    initialized_clients: &HashSet<String>,
+    client_pubkey: &str,
+    message: &JsonRpcMessage,
+) -> bool {
+    if initialized_clients.contains(client_pubkey) {
+        return false;
+    }
+
+    matches!(message, JsonRpcMessage::Request(req) if req.method != "initialize")
+}
+
+fn is_synthetic_initialize_message(message: &JsonRpcMessage) -> bool {
+    matches!(
+        message,
+        JsonRpcMessage::Request(req)
+            if req.method == "initialize"
+                && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
+    )
+}
 
 /// rmcp server worker wrapper for ContextVM Nostr server transport.
 ///
@@ -80,6 +126,7 @@ impl Worker for NostrServerWorker {
         })?;
 
         let cancellation_token = context.cancellation_token.clone();
+        let mut initialized_clients = HashSet::new();
 
         let quit_reason = loop {
             tokio::select! {
@@ -94,52 +141,67 @@ impl Worker for NostrServerWorker {
                     let crate::transport::server::IncomingRequest {
                         mut message,
                         event_id,
+                        client_pubkey,
                         ..
                     } = incoming;
 
-                    let is_synthetic_initialize = matches!(
+                    let should_inject_bootstrap = should_inject_stateless_bootstrap(
+                        &initialized_clients,
+                        &client_pubkey,
                         &message,
-                        JsonRpcMessage::Request(req)
-                            if req.method == "initialize"
-                                && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
                     );
+
+                    if should_inject_bootstrap {
+                        let synthetic_init = synthetic_initialize_message();
+                        let Some(rmcp_init) = internal_to_rmcp_server_rx(&synthetic_init) else {
+                            break WorkerQuitReason::fatal(
+                                Self::Error::Validation(
+                                    "failed converting synthetic initialize request to rmcp format".to_string(),
+                                ),
+                                "converting synthetic initialize request",
+                            );
+                        };
+
+                        if let Err(reason) = context.send_to_handler(rmcp_init).await {
+                            break reason;
+                        }
+
+                        let initialized = synthetic_initialized_notification();
+                        let Some(rmcp_initialized) = internal_to_rmcp_server_rx(&initialized) else {
+                            break WorkerQuitReason::fatal(
+                                Self::Error::Validation(
+                                    "failed converting synthetic initialized notification to rmcp format".to_string(),
+                                ),
+                                "converting synthetic initialized notification",
+                            );
+                        };
+
+                        if let Err(reason) = context.send_to_handler(rmcp_initialized).await {
+                            break reason;
+                        }
+
+                        initialized_clients.insert(client_pubkey.clone());
+                    }
+
+                    if matches!(&message, JsonRpcMessage::Request(req) if req.method == "initialize")
+                        || matches!(&message, JsonRpcMessage::Notification(n) if n.method == "notifications/initialized")
+                    {
+                        initialized_clients.insert(client_pubkey.clone());
+                    }
 
                     // Rewrite real wire requests to the Nostr event_id.
                     // Synthetic stateless bootstrap messages must retain their
                     // sentinel ID so their responses can be dropped before they
                     // ever touch transport correlation.
-                    if !is_synthetic_initialize {
+                    if !is_synthetic_initialize_message(&message) {
                         if let JsonRpcMessage::Request(ref mut req) = message {
-                            req.id = serde_json::json!(event_id);
+                        req.id = serde_json::json!(event_id);
                         }
                     }
 
                     if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&message) {
                         if let Err(reason) = context.send_to_handler(rmcp_msg).await {
                             break reason;
-                        }
-
-                        if is_synthetic_initialize {
-                            let initialized = JsonRpcMessage::Notification(
-                                crate::core::types::JsonRpcNotification {
-                                    jsonrpc: "2.0".to_string(),
-                                    method: "notifications/initialized".to_string(),
-                                    params: None,
-                                },
-                            );
-
-                            let Some(rmcp_initialized) = internal_to_rmcp_server_rx(&initialized) else {
-                                break WorkerQuitReason::fatal(
-                                    Self::Error::Validation(
-                                        "failed converting synthetic initialized notification to rmcp format".to_string(),
-                                    ),
-                                    "converting synthetic initialized notification",
-                                );
-                            };
-
-                            if let Err(reason) = context.send_to_handler(rmcp_initialized).await {
-                                break reason;
-                            }
                         }
                     } else {
                         tracing::warn!(
@@ -352,35 +414,50 @@ impl NostrServerWorker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::types::{JsonRpcRequest, JsonRpcResponse};
+    use crate::core::types::JsonRpcResponse;
+
+    #[test]
+    fn test_should_inject_stateless_bootstrap_for_first_non_initialize_request() {
+        let initialized_clients = HashSet::new();
+        let message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        assert!(should_inject_stateless_bootstrap(
+            &initialized_clients,
+            "client-a",
+            &message,
+        ));
+    }
+
+    #[test]
+    fn test_should_not_inject_stateless_bootstrap_for_real_initialize() {
+        let initialized_clients = HashSet::new();
+        let message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "initialize".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        assert!(!should_inject_stateless_bootstrap(
+            &initialized_clients,
+            "client-a",
+            &message,
+        ));
+    }
 
     #[test]
     fn test_synthetic_initialize_keeps_sentinel_id() {
-        let mut message = JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID),
-            method: "initialize".to_string(),
-            params: Some(serde_json::json!({
-                "protocolVersion": crate::core::constants::mcp_protocol_version(),
-            })),
-        });
-
-        let is_synthetic_initialize = matches!(
-            &message,
-            JsonRpcMessage::Request(req)
-                if req.method == "initialize"
-                    && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
-        );
-
-        if !is_synthetic_initialize {
-            if let JsonRpcMessage::Request(ref mut req) = message {
-                req.id = serde_json::json!("real-event-id");
-            }
-        }
+        let message = synthetic_initialize_message();
 
         match message {
             JsonRpcMessage::Request(req) => {
                 assert_eq!(req.id, serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID));
+                assert_eq!(req.method, "initialize");
             }
             other => panic!("expected request, got {other:?}"),
         }
@@ -395,17 +472,8 @@ mod tests {
             params: Some(serde_json::json!({})),
         });
 
-        let is_synthetic_initialize = matches!(
-            &message,
-            JsonRpcMessage::Request(req)
-                if req.method == "initialize"
-                    && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
-        );
-
-        if !is_synthetic_initialize {
-            if let JsonRpcMessage::Request(ref mut req) = message {
-                req.id = serde_json::json!("real-event-id");
-            }
+        if let JsonRpcMessage::Request(ref mut req) = message {
+            req.id = serde_json::json!("real-event-id");
         }
 
         match message {
@@ -430,5 +498,23 @@ mod tests {
             }
             other => panic!("expected response, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_synthetic_initialized_notification_shape() {
+        let message = synthetic_initialized_notification();
+        match message {
+            JsonRpcMessage::Notification(notification) => {
+                assert_eq!(notification.method, "notifications/initialized");
+            }
+            other => panic!("expected notification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_is_synthetic_initialize_message_detects_sentinel() {
+        assert!(is_synthetic_initialize_message(
+            &synthetic_initialize_message()
+        ));
     }
 }

--- a/src/rmcp_transport/worker.rs
+++ b/src/rmcp_transport/worker.rs
@@ -15,6 +15,7 @@ use super::convert::{
 };
 
 const LOG_TARGET: &str = "contextvm_sdk::rmcp_transport::worker";
+const STATELESS_SYNTHETIC_EVENT_ID: &str = "contextvm-stateless-init";
 
 /// rmcp server worker wrapper for ContextVM Nostr server transport.
 ///
@@ -96,18 +97,49 @@ impl Worker for NostrServerWorker {
                         ..
                     } = incoming;
 
-                    // Rewrite the JSON-RPC request ID to the Nostr event_id.
-                    // Event IDs are globally unique (SHA-256), so no collision
-                    // across clients.  The transport's event-route store maps
-                    // event_id → (client_pubkey, original_request_id) and
-                    // restores the original ID in `send_response`.
-                    if let JsonRpcMessage::Request(ref mut req) = message {
-                        req.id = serde_json::json!(event_id);
+                    let is_synthetic_initialize = matches!(
+                        &message,
+                        JsonRpcMessage::Request(req)
+                            if req.method == "initialize"
+                                && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
+                    );
+
+                    // Rewrite real wire requests to the Nostr event_id.
+                    // Synthetic stateless bootstrap messages must retain their
+                    // sentinel ID so their responses can be dropped before they
+                    // ever touch transport correlation.
+                    if !is_synthetic_initialize {
+                        if let JsonRpcMessage::Request(ref mut req) = message {
+                            req.id = serde_json::json!(event_id);
+                        }
                     }
 
                     if let Some(rmcp_msg) = internal_to_rmcp_server_rx(&message) {
                         if let Err(reason) = context.send_to_handler(rmcp_msg).await {
                             break reason;
+                        }
+
+                        if is_synthetic_initialize {
+                            let initialized = JsonRpcMessage::Notification(
+                                crate::core::types::JsonRpcNotification {
+                                    jsonrpc: "2.0".to_string(),
+                                    method: "notifications/initialized".to_string(),
+                                    params: None,
+                                },
+                            );
+
+                            let Some(rmcp_initialized) = internal_to_rmcp_server_rx(&initialized) else {
+                                break WorkerQuitReason::fatal(
+                                    Self::Error::Validation(
+                                        "failed converting synthetic initialized notification to rmcp format".to_string(),
+                                    ),
+                                    "converting synthetic initialized notification",
+                                );
+                            };
+
+                            if let Err(reason) = context.send_to_handler(rmcp_initialized).await {
+                                break reason;
+                            }
                         }
                     } else {
                         tracing::warn!(
@@ -272,6 +304,15 @@ impl NostrServerWorker {
                     )
                 })?;
 
+                if event_id == STATELESS_SYNTHETIC_EVENT_ID {
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        event_id = %event_id,
+                        "Dropping synthetic initialize response before wire transport"
+                    );
+                    return Ok(());
+                }
+
                 self.transport
                     .send_response(&event_id, JsonRpcMessage::Response(resp))
                     .await
@@ -282,6 +323,15 @@ impl NostrServerWorker {
                         "rmcp server error response id is not a string event_id".to_string(),
                     )
                 })?;
+
+                if event_id == STATELESS_SYNTHETIC_EVENT_ID {
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        event_id = %event_id,
+                        "Dropping synthetic initialize error before wire transport"
+                    );
+                    return Ok(());
+                }
 
                 self.transport
                     .send_response(&event_id, JsonRpcMessage::ErrorResponse(resp))
@@ -295,6 +345,90 @@ impl NostrServerWorker {
                 let message = JsonRpcMessage::Request(request);
                 self.transport.broadcast_notification(&message).await
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::{JsonRpcRequest, JsonRpcResponse};
+
+    #[test]
+    fn test_synthetic_initialize_keeps_sentinel_id() {
+        let mut message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID),
+            method: "initialize".to_string(),
+            params: Some(serde_json::json!({
+                "protocolVersion": crate::core::constants::mcp_protocol_version(),
+            })),
+        });
+
+        let is_synthetic_initialize = matches!(
+            &message,
+            JsonRpcMessage::Request(req)
+                if req.method == "initialize"
+                    && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
+        );
+
+        if !is_synthetic_initialize {
+            if let JsonRpcMessage::Request(ref mut req) = message {
+                req.id = serde_json::json!("real-event-id");
+            }
+        }
+
+        match message {
+            JsonRpcMessage::Request(req) => {
+                assert_eq!(req.id, serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID));
+            }
+            other => panic!("expected request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_real_request_is_rewritten_to_event_id() {
+        let mut message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        let is_synthetic_initialize = matches!(
+            &message,
+            JsonRpcMessage::Request(req)
+                if req.method == "initialize"
+                    && req.id == serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID)
+        );
+
+        if !is_synthetic_initialize {
+            if let JsonRpcMessage::Request(ref mut req) = message {
+                req.id = serde_json::json!("real-event-id");
+            }
+        }
+
+        match message {
+            JsonRpcMessage::Request(req) => {
+                assert_eq!(req.id, serde_json::json!("real-event-id"));
+            }
+            other => panic!("expected request, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_synthetic_initialize_response_uses_sentinel_for_drop() {
+        let message = JsonRpcMessage::Response(JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(STATELESS_SYNTHETIC_EVENT_ID),
+            result: serde_json::json!({}),
+        });
+
+        match message {
+            JsonRpcMessage::Response(resp) => {
+                assert_eq!(resp.id.as_str(), Some(STATELESS_SYNTHETIC_EVENT_ID));
+            }
+            other => panic!("expected response, got {other:?}"),
         }
     }
 }

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -919,6 +919,54 @@ impl NostrServerTransport {
         })
     }
 
+    #[cfg(feature = "rmcp")]
+    fn synthetic_initialize_message() -> JsonRpcMessage {
+        JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!("contextvm-stateless-init"),
+            method: "initialize".to_string(),
+            params: Some(serde_json::json!({
+                "protocolVersion": crate::core::constants::mcp_protocol_version(),
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "contextvm-stateless-client",
+                    "version": "0.1.0"
+                }
+            })),
+        })
+    }
+
+    #[cfg(not(feature = "rmcp"))]
+    fn synthetic_initialize_message() -> JsonRpcMessage {
+        JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!("contextvm-stateless-init"),
+            method: "initialize".to_string(),
+            params: Some(serde_json::json!({
+                "protocolVersion": crate::core::constants::mcp_protocol_version(),
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "contextvm-stateless-client",
+                    "version": "0.1.0"
+                }
+            })),
+        })
+    }
+
+    fn should_inject_synthetic_initialize(
+        session: &ClientSession,
+        mcp_msg: &JsonRpcMessage,
+    ) -> bool {
+        if session.is_initialized {
+            return false;
+        }
+
+        matches!(
+            mcp_msg,
+            JsonRpcMessage::Request(req) if req.method != "initialize"
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn event_loop(
         relay_pool: Arc<dyn RelayPoolTrait>,
@@ -1225,6 +1273,12 @@ impl NostrServerTransport {
                 session.supports_oversized_transfer |=
                     oversized_enabled && discovered.supports_oversized_transfer;
 
+                let should_inject_initialize =
+                    Self::should_inject_synthetic_initialize(session, &mcp_msg);
+                if should_inject_initialize {
+                    session.is_initialized = true;
+                }
+
                 // Track request for correlation
                 if let JsonRpcMessage::Request(ref req) = mcp_msg {
                     let original_id = req.id.clone();
@@ -1282,6 +1336,16 @@ impl NostrServerTransport {
                             session.is_initialized = true;
                         }
                     }
+                }
+
+                // Forward a synthetic initialize first for stateless first-request sessions.
+                if should_inject_initialize {
+                    let _ = tx.send(IncomingRequest {
+                        message: Self::synthetic_initialize_message(),
+                        client_pubkey: sender_pubkey.clone(),
+                        event_id: event_id.clone(),
+                        is_encrypted,
+                    });
                 }
 
                 // Forward to consumer
@@ -1560,6 +1624,76 @@ mod tests {
             "notifications/initialized",
             None
         ));
+    }
+
+    #[test]
+    fn test_should_inject_synthetic_initialize_for_first_non_initialize_request() {
+        let session = ClientSession::new(false);
+        let message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        assert!(NostrServerTransport::should_inject_synthetic_initialize(
+            &session, &message,
+        ));
+    }
+
+    #[test]
+    fn test_should_not_inject_synthetic_initialize_for_real_initialize_request() {
+        let session = ClientSession::new(false);
+        let message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "initialize".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        assert!(!NostrServerTransport::should_inject_synthetic_initialize(
+            &session, &message,
+        ));
+    }
+
+    #[test]
+    fn test_should_not_inject_synthetic_initialize_after_session_initialized() {
+        let mut session = ClientSession::new(false);
+        session.is_initialized = true;
+        let message = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "tools/list".to_string(),
+            params: Some(serde_json::json!({})),
+        });
+
+        assert!(!NostrServerTransport::should_inject_synthetic_initialize(
+            &session, &message,
+        ));
+    }
+
+    #[test]
+    fn test_synthetic_initialize_message_shape() {
+        let message = NostrServerTransport::synthetic_initialize_message();
+        let JsonRpcMessage::Request(request) = message else {
+            panic!("expected request");
+        };
+
+        assert_eq!(request.method, "initialize");
+        assert_eq!(request.id, serde_json::json!("contextvm-stateless-init"));
+
+        let params = request.params.expect("initialize params");
+        assert_eq!(
+            params.get("protocolVersion").and_then(|v| v.as_str()),
+            Some(crate::core::constants::mcp_protocol_version())
+        );
+        assert_eq!(
+            params
+                .get("clientInfo")
+                .and_then(|v| v.get("name"))
+                .and_then(|v| v.as_str()),
+            Some("contextvm-stateless-client")
+        );
     }
 
     #[test]

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -919,54 +919,6 @@ impl NostrServerTransport {
         })
     }
 
-    #[cfg(feature = "rmcp")]
-    fn synthetic_initialize_message() -> JsonRpcMessage {
-        JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: serde_json::json!("contextvm-stateless-init"),
-            method: "initialize".to_string(),
-            params: Some(serde_json::json!({
-                "protocolVersion": crate::core::constants::mcp_protocol_version(),
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "contextvm-stateless-client",
-                    "version": "0.1.0"
-                }
-            })),
-        })
-    }
-
-    #[cfg(not(feature = "rmcp"))]
-    fn synthetic_initialize_message() -> JsonRpcMessage {
-        JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: serde_json::json!("contextvm-stateless-init"),
-            method: "initialize".to_string(),
-            params: Some(serde_json::json!({
-                "protocolVersion": crate::core::constants::mcp_protocol_version(),
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "contextvm-stateless-client",
-                    "version": "0.1.0"
-                }
-            })),
-        })
-    }
-
-    fn should_inject_synthetic_initialize(
-        session: &ClientSession,
-        mcp_msg: &JsonRpcMessage,
-    ) -> bool {
-        if session.is_initialized {
-            return false;
-        }
-
-        matches!(
-            mcp_msg,
-            JsonRpcMessage::Request(req) if req.method != "initialize"
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     async fn event_loop(
         relay_pool: Arc<dyn RelayPoolTrait>,
@@ -1273,12 +1225,6 @@ impl NostrServerTransport {
                 session.supports_oversized_transfer |=
                     oversized_enabled && discovered.supports_oversized_transfer;
 
-                let should_inject_initialize =
-                    Self::should_inject_synthetic_initialize(session, &mcp_msg);
-                if should_inject_initialize {
-                    session.is_initialized = true;
-                }
-
                 // Track request for correlation
                 if let JsonRpcMessage::Request(ref req) = mcp_msg {
                     let original_id = req.id.clone();
@@ -1336,16 +1282,6 @@ impl NostrServerTransport {
                             session.is_initialized = true;
                         }
                     }
-                }
-
-                // Forward a synthetic initialize first for stateless first-request sessions.
-                if should_inject_initialize {
-                    let _ = tx.send(IncomingRequest {
-                        message: Self::synthetic_initialize_message(),
-                        client_pubkey: sender_pubkey.clone(),
-                        event_id: event_id.clone(),
-                        is_encrypted,
-                    });
                 }
 
                 // Forward to consumer
@@ -1624,76 +1560,6 @@ mod tests {
             "notifications/initialized",
             None
         ));
-    }
-
-    #[test]
-    fn test_should_inject_synthetic_initialize_for_first_non_initialize_request() {
-        let session = ClientSession::new(false);
-        let message = JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: serde_json::json!(1),
-            method: "tools/list".to_string(),
-            params: Some(serde_json::json!({})),
-        });
-
-        assert!(NostrServerTransport::should_inject_synthetic_initialize(
-            &session, &message,
-        ));
-    }
-
-    #[test]
-    fn test_should_not_inject_synthetic_initialize_for_real_initialize_request() {
-        let session = ClientSession::new(false);
-        let message = JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: serde_json::json!(1),
-            method: "initialize".to_string(),
-            params: Some(serde_json::json!({})),
-        });
-
-        assert!(!NostrServerTransport::should_inject_synthetic_initialize(
-            &session, &message,
-        ));
-    }
-
-    #[test]
-    fn test_should_not_inject_synthetic_initialize_after_session_initialized() {
-        let mut session = ClientSession::new(false);
-        session.is_initialized = true;
-        let message = JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: serde_json::json!(1),
-            method: "tools/list".to_string(),
-            params: Some(serde_json::json!({})),
-        });
-
-        assert!(!NostrServerTransport::should_inject_synthetic_initialize(
-            &session, &message,
-        ));
-    }
-
-    #[test]
-    fn test_synthetic_initialize_message_shape() {
-        let message = NostrServerTransport::synthetic_initialize_message();
-        let JsonRpcMessage::Request(request) = message else {
-            panic!("expected request");
-        };
-
-        assert_eq!(request.method, "initialize");
-        assert_eq!(request.id, serde_json::json!("contextvm-stateless-init"));
-
-        let params = request.params.expect("initialize params");
-        assert_eq!(
-            params.get("protocolVersion").and_then(|v| v.as_str()),
-            Some(crate::core::constants::mcp_protocol_version())
-        );
-        assert_eq!(
-            params
-                .get("clientInfo")
-                .and_then(|v| v.get("name"))
-                .and_then(|v| v.as_str()),
-            Some("contextvm-stateless-client")
-        );
     }
 
     #[test]


### PR DESCRIPTION
Stateless clients were being rejected by the server because RMCP imposed the initialization lifecycle.

- inject synthetic `initialize` for first stateless inbound request in [`src/transport/server/mod.rs`](src/transport/server/mod.rs)
- inject synthetic [`notifications/initialized`](src/rmcp_transport/worker.rs) inside the rmcp worker bridge
- preserve real Nostr event-id correlation by keeping synthetic bootstrap messages on a sentinel id in [`src/rmcp_transport/worker.rs`](src/rmcp_transport/worker.rs)
- drop synthetic bootstrap responses before they reach wire transport in [`src/rmcp_transport/worker.rs`](src/rmcp_transport/worker.rs)
- add mock-relay end-to-end stateless rmcp regression coverage in [`src/rmcp_transport/pipeline_tests.rs`](src/rmcp_transport/pipeline_tests.rs)