### PR TITLE
chore: bump to 0.1.1, publishing config and quality improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.1] - 2026-05-08
+
+### Fixed
+
+- Corrected crates.io metadata (repository URL, keywords, categories, homepage, documentation)
+
 ## [0.1.0] - 2026-05-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextvm-sdk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.70"
 description = "Rust SDK for the ContextVM protocol — MCP over Nostr"
@@ -43,6 +43,8 @@ tokio-util = { version = "0.7", features = ["rt"] }
 # Enable rmcp by default while keeping legacy APIs available.
 default = ["rmcp"]
 rmcp = ["dep:rmcp"]
+## Exposes `MockRelayPool` for use in downstream integration tests.
+test-utils = []
 
 [[example]]
 name = "rmcp_integration_test"
@@ -55,6 +57,10 @@ required-features = ["rmcp"]
 [[example]]
 name = "native_echo_client"
 required-features = ["rmcp"]
+
+[[test]]
+name = "transport_integration"
+required-features = ["test-utils"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-contextvm-sdk = { git = "https://github.com/k0sti/rust-contextvm-sdk" }
+contextvm-sdk = { git = "https://github.com/ContextVM/rs-sdk" }
 ```
 
 Or clone and use as a path dependency:

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -114,7 +114,7 @@ impl ServerInfo {
 // ── Client session ──────────────────────────────────────────────────
 
 /// Client session state tracked by the server transport.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClientSession {
     /// Whether the client has completed MCP initialization.
     pub is_initialized: bool,
@@ -294,7 +294,7 @@ impl JsonRpcMessage {
 // ── Capability exclusion ────────────────────────────────────────────
 
 /// A capability exclusion pattern that bypasses pubkey whitelisting.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CapabilityExclusion {
     /// The JSON-RPC method to exclude (e.g., "tools/call", "tools/list").
     pub method: String,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -8,6 +8,7 @@ use crate::core::types::JsonRpcMessage;
 use crate::transport::server::{IncomingRequest, NostrServerTransport, NostrServerTransportConfig};
 
 /// Configuration for the gateway.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct GatewayConfig {
     /// Nostr server transport configuration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub use core::types::{
     ServerInfo,
 };
 pub use discovery::ServerAnnouncement;
+#[cfg(any(test, feature = "test-utils"))]
 pub use relay::mock::MockRelayPool;
 pub use relay::{RelayPool, RelayPoolTrait};
 pub use transport::client::{

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -8,6 +8,7 @@ use crate::core::types::JsonRpcMessage;
 use crate::transport::client::{NostrClientTransport, NostrClientTransportConfig};
 
 /// Configuration for the proxy.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ProxyConfig {
     /// Nostr client transport configuration.

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! Wraps nostr-sdk's Client for relay connection, event publishing, and subscription.
 
+#[cfg(any(test, feature = "test-utils"))]
 pub mod mock;
+#[cfg(any(test, feature = "test-utils"))]
 pub use mock::MockRelayPool;
 
 use async_trait::async_trait;

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -29,6 +29,7 @@ use crate::transport::discovery_tags::{parse_discovered_peer_capabilities, PeerC
 const LOG_TARGET: &str = "contextvm_sdk::transport::client";
 
 /// Configuration for the client transport.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct NostrClientTransportConfig {
     /// Relay URLs to connect to.

--- a/src/transport/server/mod.rs
+++ b/src/transport/server/mod.rs
@@ -32,6 +32,7 @@ use crate::transport::discovery_tags::learn_peer_capabilities;
 const LOG_TARGET: &str = "contextvm_sdk::transport::server";
 
 /// Configuration for the server transport.
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct NostrServerTransportConfig {
     /// Relay URLs to connect to.


### PR DESCRIPTION
Fixes Quality improvements from issue #65 and bumped to 0.1.1 in cargo.toml, also updated changelog.md (added 0.1.1), also fixed old fork URL in README git install instruction.

cargo publish --dry-run passes cleanly.