### PR TITLE
ci: add MSRV and feature matrix checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,18 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+      - name: Check (no-default-features)
+        run: cargo check --no-default-features
+
+      - name: Test (no-default-features)
+        run: cargo test --no-default-features
+
+      - name: Check (default features)
+        run: cargo check
+
+      - name: Test (default features)
+        run: cargo test
+
   msrv:
     name: MSRV (Rust 1.88)
     runs-on: ubuntu-latest
@@ -63,27 +75,3 @@ jobs:
 
       - name: Test
         run: cargo test --all-features
-
-  features:
-    name: Feature matrix
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        features: ["--no-default-features", "", "--all-features"]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Check
-        run: cargo check ${{ matrix.features }}
-
-      - name: Test
-        run: cargo test ${{ matrix.features }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,3 +40,50 @@ jobs:
 
       - name: Build
         run: cargo build --verbose
+
+  msrv:
+    name: MSRV (Rust 1.88)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@1.88
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Remove incompatible lockfile
+        run: rm -f Cargo.lock
+
+      - name: Check
+        run: cargo check --all-features
+
+      - name: Test
+        run: cargo test --all-features
+
+  features:
+    name: Feature matrix
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        features: ["--no-default-features", "", "--all-features"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check
+        run: cargo check ${{ matrix.features }}
+
+      - name: Test
+        run: cargo test ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "contextvm-sdk"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.88"
 description = "Rust SDK for the ContextVM protocol — MCP over Nostr"
 license = "MIT"
 readme = "README.md"
@@ -57,6 +57,10 @@ required-features = ["rmcp"]
 [[example]]
 name = "native_echo_client"
 required-features = ["rmcp"]
+
+[[test]]
+name = "e2e_happy_path"
+required-features = ["rmcp", "test-utils"]
 
 [[test]]
 name = "transport_integration"


### PR DESCRIPTION
Adds two new CI jobs and fixes two bugs caught while testing them locally.

New jobs:
- MSRV - builds and tests on Rust 1.88 (the actual minimum, verified against all deps)
- Feature matrix - tests --no-default-features, default, and --all-features combinations

Bugs fixed:
- rust-version was declared as "1.70" but the real minimum is 1.88 due to dependencies (rmcp uses edition 2024, darling requires 1.88)
- e2e_happy_path test was missing required-features = ["rmcp", "test-utils"] in Cargo.toml, causing default feature builds to fail