### PR TITLE
feat: multi-stage relay resolution and transport integration (CEP-17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ ContextVM maps MCP's JSON-RPC 2.0 messages onto Nostr events:
 |---------|------------------------|-------------|--------------------------------------|
 | `25910` | ContextVM Messages     | Ephemeral   | MCP request/response/notification    |
 | `1059`  | Gift Wrap (NIP-59)     | Regular     | Encrypted MCP messages               |
+| `21059` | Ephemeral Gift Wrap    | Ephemeral   | Encrypted MCP messages (CEP-19)      |
+| `10002` | Relay List Metadata    | Replaceable | Server's advertised relays (CEP-17)  |
 | `11316` | Server Announcement    | Addressable | Server identity & metadata           |
 | `11317` | Tools List             | Addressable | Published tool capabilities          |
 | `11318` | Resources List         | Addressable | Published resource capabilities      |
@@ -211,20 +213,28 @@ metadata-private delivery. Server announcements (kinds 11316–11320) are always
 | `relay_urls`             | `["wss://relay.damus.io"]` | Nostr relays to connect to          |
 | `encryption_mode`        | `Optional`            | Encryption policy                        |
 | `server_info`            | `None`                | Server metadata for announcements        |
-| `is_announced_server`    | `false`               | Whether to publish announcements (CEP-6) |
+| `is_announced_server`    | `false`               | Auto-publish announcements on start (CEP-6) |
 | `allowed_public_keys`    | `[]` (allow all)      | Client pubkey allowlist (hex)            |
 | `excluded_capabilities`  | `[]`                  | Methods exempt from allowlist            |
 | `session_timeout`        | `300s`                | Inactive session expiry                  |
+| `relay_list_urls`        | `None`                | Relay URLs for kind 10002 (CEP-17); defaults to `relay_urls` |
+| `bootstrap_relay_urls`   | `None`                | Additional relays for publishing announcements (CEP-6/17) |
+| `publish_relay_list`     | `true`                | Whether to publish kind 10002 relay list metadata |
+| `profile_metadata`       | `None`                | Profile metadata for kind 0 publication (CEP-23) |
 
 ### Client Transport Config
 
-| Field             | Default                    | Description                          |
-|-------------------|----------------------------|--------------------------------------|
-| `relay_urls`      | `["wss://relay.damus.io"]` | Nostr relays to connect to           |
-| `server_pubkey`   | (required)                 | Target server's public key (hex)     |
-| `encryption_mode` | `Optional`                 | Encryption policy                    |
-| `is_stateless`    | `false`                    | Emulate initialize locally           |
-| `timeout`         | `30s`                      | Response timeout                     |
+| Field                              | Default                    | Description                          |
+|------------------------------------|----------------------------|--------------------------------------|
+| `relay_urls`                       | `[]`                       | Nostr relays to connect to (empty = use relay resolution) |
+| `server_pubkey`                    | (required)                 | Target server's public key (hex, npub, or nprofile) |
+| `encryption_mode`                  | `Optional`                 | Encryption policy                    |
+| `is_stateless`                     | `false`                    | Emulate initialize locally           |
+| `timeout`                          | `30s`                      | Response timeout                     |
+| `discovery_relay_urls`             | `None` (bootstrap relays)  | Relays for CEP-17 kind 10002 discovery |
+| `fallback_operational_relay_urls`  | `None`                     | Relays probed in parallel with CEP-17 discovery |
+
+When `relay_urls` is empty, `start()` runs automatic relay resolution: configured relays > nprofile hints > CEP-17 kind 10002 discovery > fallback probing > bootstrap defaults.
 
 ## References
 

--- a/docs/client-transport.md
+++ b/docs/client-transport.md
@@ -147,12 +147,14 @@ This is the ContextVM equivalent of the usual `rmcp` client workflow, but using 
 
 Start with these fields in `NostrClientTransportConfig`:
 
-- `relay_urls`: relays the client uses to reach the server
-- `server_pubkey`: the target server public key
+- `relay_urls`: relays the client uses to reach the server (empty = use relay resolution)
+- `server_pubkey`: the target server's public key (hex, npub, or nprofile with relay hints)
 - `encryption_mode`: whether plaintext is allowed
 - `gift_wrap_mode`: whether to use persistent or ephemeral wrapping
 - `is_stateless`: whether initialize is emulated locally for stateless workflows
 - `timeout`: how long request correlation waits for a response
+- `discovery_relay_urls`: bootstrap relays for CEP-17 kind 10002 relay-list discovery (defaults to `DEFAULT_BOOTSTRAP_RELAY_URLS`)
+- `fallback_operational_relay_urls`: non-authoritative relays probed in parallel with CEP-17 discovery
 
 ## When to use this instead of the proxy
 
@@ -166,3 +168,4 @@ Use the proxy guide when you want a simpler message-oriented bridge and do not w
 - The initialize request is sent automatically as part of the running client startup sequence.
 - Stateless initialization behavior is covered by the conformance tests.
 - Capability learning and gift-wrap handling happen inside the client transport implementation.
+- When `relay_urls` is empty, `start()` runs 6-stage relay resolution before connecting: configured relays > nprofile hints > CEP-17 kind 10002 discovery > fallback probing > bootstrap defaults. Callers can set `server_pubkey` to an nprofile and omit `relay_urls` entirely.

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -59,6 +59,26 @@ The event kinds follow the public announcement model summarized in the repositor
 
 These event kinds are the SDK's public discovery model for server metadata and advertised MCP capabilities.
 
+## CEP-17 automatic relay resolution
+
+Clients can discover which relays a server uses without hardcoding relay URLs. Set `server_pubkey` to an nprofile (which embeds relay hints) and leave `relay_urls` empty:
+
+```rust
+NostrClientTransportConfig::default()
+    .with_server_pubkey("nprofile1...") // contains pubkey + relay hints
+```
+
+When `start()` is called with empty `relay_urls`, the transport runs a 6-stage resolution pipeline:
+
+1. **Configured relays** -- if `relay_urls` is non-empty, use them directly
+2. **nprofile hints** -- relay URLs embedded in the nprofile identity
+3. **CEP-17 discovery** -- fetch kind 10002 relay-list events from bootstrap relays
+4. **Fallback probing** -- probe `fallback_operational_relay_urls` in parallel with discovery
+5. **Sequential fallback** -- if the race winner returned empty, await the other
+6. **Bootstrap default** -- fall back to `DEFAULT_BOOTSTRAP_RELAY_URLS` as last resort
+
+The `discovery_relay_urls` and `fallback_operational_relay_urls` config fields customize stages 3-4.
+
 ## Important limitations
 
 - discovery is public metadata, not a replacement for direct transport negotiation

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -109,10 +109,14 @@ The main operational knobs live on `NostrServerTransportConfig`:
 - `encryption_mode`: plaintext vs encrypted session policy
 - `gift_wrap_mode`: choose between persistent and ephemeral gift wraps
 - `server_info`: metadata used in public announcements
-- `is_announced_server`: publish public discovery events
+- `is_announced_server`: auto-publish announcements on start (CEP-6)
 - `allowed_public_keys`: static client allowlist
 - `excluded_capabilities`: allow public access to specific methods or capability names
 - `max_sessions`, `cleanup_interval`, `session_timeout`: server-side session lifecycle
+- `relay_list_urls`: relay URLs advertised in kind 10002 (CEP-17); defaults to `relay_urls`
+- `bootstrap_relay_urls`: additional relays for publishing announcements (CEP-6/17)
+- `publish_relay_list`: whether to publish kind 10002 relay list metadata; default `true`
+- `profile_metadata`: optional profile metadata for kind 0 publication (CEP-23)
 
 ## Behavioral notes
 

--- a/docs/server-transport.md
+++ b/docs/server-transport.md
@@ -158,6 +158,10 @@ Start with these fields in `NostrServerTransportConfig`:
 - `gift_wrap_mode`: persistent vs ephemeral wrapping policy
 - `allowed_public_keys`: allowlist for private or restricted servers
 - `excluded_capabilities`: allow specific methods without fully opening the server
+- `relay_list_urls`: relay URLs advertised in kind 10002 (CEP-17); defaults to `relay_urls`
+- `bootstrap_relay_urls`: additional relays for publishing announcements (CEP-6/17); merged with `relay_list_urls`
+- `publish_relay_list`: whether to publish kind 10002 relay list metadata; default `true`
+- `profile_metadata`: optional profile metadata for kind 0 publication (CEP-23)
 
 ## When to use this instead of the gateway
 
@@ -171,3 +175,4 @@ Use the gateway guide when you already have a request loop or existing local MCP
 - `rmcp` accepts pre-init ping and enters the main loop immediately after initialization completes.
 - ContextVM response routing depends on request event ids.
 - Encryption mirroring and announcement behavior are covered by the integration tests.
+- When `is_announced_server` is `true`, the transport auto-publishes all announcement events on `start()` via synthetic MCP requests: kind 11316 (server announcement), kinds 11317-11320 (tools, resources, templates, prompts), kind 10002 (relay list), and kind 0 (profile metadata if configured).

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -122,6 +122,8 @@ mod tests {
             gift_wrap_mode: GiftWrapMode::Optional,
             is_stateless: true,
             timeout: Duration::from_secs(60),
+            discovery_relay_urls: None,
+            fallback_operational_relay_urls: None,
         };
 
         let config = ProxyConfig { nostr_config };

--- a/src/transport/client/mod.rs
+++ b/src/transport/client/mod.rs
@@ -4,6 +4,7 @@
 //! kind 25910 events, correlates responses via `e` tag.
 
 pub mod correlation_store;
+pub mod relay_resolution;
 pub mod server_identity;
 pub mod server_relay_discovery;
 
@@ -53,17 +54,24 @@ pub struct NostrClientTransportConfig {
     /// This prevents leaks -- rmcp owns actual request timeout and cancellation.
     /// Keep this value above your rmcp request timeout to avoid premature cleanup.
     pub timeout: Duration,
+    /// Relay URLs used for CEP-17 relay-list discovery when operational relays are not configured.
+    /// Overrides `DEFAULT_BOOTSTRAP_RELAY_URLS` when provided.
+    pub discovery_relay_urls: Option<Vec<String>>,
+    /// Non-authoritative operational relays probed in parallel with CEP-17 discovery.
+    pub fallback_operational_relay_urls: Option<Vec<String>>,
 }
 
 impl Default for NostrClientTransportConfig {
     fn default() -> Self {
         Self {
-            relay_urls: vec!["wss://relay.damus.io".to_string()],
+            relay_urls: vec![],
             server_pubkey: String::new(),
             encryption_mode: EncryptionMode::Optional,
             gift_wrap_mode: GiftWrapMode::Optional,
             is_stateless: false,
             timeout: Duration::from_secs(30),
+            discovery_relay_urls: None,
+            fallback_operational_relay_urls: None,
         }
     }
 }
@@ -99,6 +107,16 @@ impl NostrClientTransportConfig {
         self.timeout = timeout;
         self
     }
+    /// Set relay URLs for CEP-17 relay-list discovery.
+    pub fn with_discovery_relay_urls(mut self, urls: Vec<String>) -> Self {
+        self.discovery_relay_urls = Some(urls);
+        self
+    }
+    /// Set fallback operational relay URLs probed in parallel with discovery.
+    pub fn with_fallback_operational_relay_urls(mut self, urls: Vec<String>) -> Self {
+        self.fallback_operational_relay_urls = Some(urls);
+        self
+    }
 }
 
 /// Client-side Nostr transport for sending MCP requests and receiving responses.
@@ -107,8 +125,11 @@ pub struct NostrClientTransport {
     config: NostrClientTransportConfig,
     server_pubkey: PublicKey,
     /// Populated from nprofile relay hints; used by relay resolution in `start()` (CEP-17).
-    #[allow(dead_code)]
     hinted_relay_urls: Vec<String>,
+    /// Discovery relay URLs for CEP-17 kind 10002 lookup.
+    discovery_relay_urls: Vec<String>,
+    /// Fallback operational relay URLs probed in parallel with discovery.
+    fallback_operational_relay_urls: Vec<String>,
     /// Pending request event IDs awaiting responses.
     pending_requests: ClientCorrelationStore,
     /// CEP-35: one-shot flag for client discovery tag emission.
@@ -170,6 +191,17 @@ impl NostrClientTransport {
             encryption_mode = ?config.encryption_mode,
             "Created client transport"
         );
+        let discovery_relay_urls = config.discovery_relay_urls.clone().unwrap_or_else(|| {
+            DEFAULT_BOOTSTRAP_RELAY_URLS
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        });
+        let fallback_operational_relay_urls = config
+            .fallback_operational_relay_urls
+            .clone()
+            .unwrap_or_default();
+
         Ok(Self {
             base: BaseTransport {
                 relay_pool,
@@ -179,6 +211,8 @@ impl NostrClientTransport {
             config,
             server_pubkey,
             hinted_relay_urls,
+            discovery_relay_urls,
+            fallback_operational_relay_urls,
             pending_requests: ClientCorrelationStore::new(),
             has_sent_discovery_tags: AtomicBool::new(false),
             discovered_server_capabilities: Arc::new(Mutex::new(PeerCapabilities::default())),
@@ -213,6 +247,17 @@ impl NostrClientTransport {
             NonZeroUsize::new(DEFAULT_LRU_SIZE).expect("DEFAULT_LRU_SIZE must be non-zero"),
         )));
 
+        let discovery_relay_urls = config.discovery_relay_urls.clone().unwrap_or_else(|| {
+            DEFAULT_BOOTSTRAP_RELAY_URLS
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        });
+        let fallback_operational_relay_urls = config
+            .fallback_operational_relay_urls
+            .clone()
+            .unwrap_or_default();
+
         tracing::info!(
             target: LOG_TARGET,
             relay_count = config.relay_urls.len(),
@@ -229,6 +274,8 @@ impl NostrClientTransport {
             config,
             server_pubkey,
             hinted_relay_urls,
+            discovery_relay_urls,
+            fallback_operational_relay_urls,
             pending_requests: ClientCorrelationStore::new(),
             has_sent_discovery_tags: AtomicBool::new(false),
             discovered_server_capabilities: Arc::new(Mutex::new(PeerCapabilities::default())),
@@ -244,17 +291,32 @@ impl NostrClientTransport {
 
     /// Connect and start listening for responses.
     pub async fn start(&mut self) -> Result<()> {
-        self.base
-            .connect(&self.config.relay_urls)
-            .await
-            .map_err(|error| {
-                tracing::error!(
-                    target: LOG_TARGET,
-                    error = %error,
-                    "Failed to connect client transport to relays"
-                );
-                error
-            })?;
+        let resolved_urls =
+            relay_resolution::resolve_operational_relays(relay_resolution::RelayResolutionConfig {
+                configured_relay_urls: self.config.relay_urls.clone(),
+                hinted_relay_urls: self.hinted_relay_urls.clone(),
+                discovery_relay_urls: self.discovery_relay_urls.clone(),
+                fallback_operational_relay_urls: self.fallback_operational_relay_urls.clone(),
+                server_pubkey: self.server_pubkey,
+                signer: self.base.relay_pool.signer().await?,
+                timeout: Duration::from_millis(DEFAULT_TIMEOUT_MS),
+            })
+            .await;
+
+        let connect_urls = if resolved_urls.is_empty() {
+            &self.config.relay_urls
+        } else {
+            &resolved_urls
+        };
+
+        self.base.connect(connect_urls).await.map_err(|error| {
+            tracing::error!(
+                target: LOG_TARGET,
+                error = %error,
+                "Failed to connect client transport to relays"
+            );
+            error
+        })?;
 
         let pubkey = self.base.get_public_key().await.map_err(|error| {
             tracing::error!(
@@ -863,12 +925,14 @@ mod tests {
     #[test]
     fn test_config_defaults() {
         let config = NostrClientTransportConfig::default();
-        assert_eq!(config.relay_urls, vec!["wss://relay.damus.io".to_string()]);
+        assert!(config.relay_urls.is_empty());
         assert!(config.server_pubkey.is_empty());
         assert_eq!(config.encryption_mode, EncryptionMode::Optional);
         assert_eq!(config.gift_wrap_mode, GiftWrapMode::Optional);
         assert!(!config.is_stateless);
         assert_eq!(config.timeout, Duration::from_secs(30));
+        assert!(config.discovery_relay_urls.is_none());
+        assert!(config.fallback_operational_relay_urls.is_none());
     }
 
     #[test]
@@ -1105,6 +1169,8 @@ mod tests {
             },
             server_pubkey: keys.public_key(),
             hinted_relay_urls: vec![],
+            discovery_relay_urls: vec![],
+            fallback_operational_relay_urls: vec![],
             pending_requests: ClientCorrelationStore::new(),
             has_sent_discovery_tags: AtomicBool::new(false),
             discovered_server_capabilities: Arc::new(Mutex::new(PeerCapabilities::default())),

--- a/src/transport/client/relay_resolution.rs
+++ b/src/transport/client/relay_resolution.rs
@@ -1,0 +1,369 @@
+//! CEP-17 multi-stage relay resolution.
+//!
+//! Resolves operational relays via: config → nprofile hints → kind 10002
+//! discovery → fallback probing → bootstrap defaults.
+//! Mirrors the TS SDK's `resolveOperationalRelays()` and
+//! `connectFallbackOperationalRelays()`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nostr_sdk::prelude::*;
+use tokio::pin;
+
+use crate::relay::RelayPool;
+use crate::transport::client::server_relay_discovery::{
+    fetch_server_relay_list, select_operational_relay_urls,
+};
+
+const LOG_TARGET: &str = "contextvm_sdk::transport::client::relay_resolution";
+
+/// Inputs for multi-stage relay resolution.
+pub struct RelayResolutionConfig {
+    /// Explicitly configured relay URLs (stage 1).
+    pub configured_relay_urls: Vec<String>,
+    /// Relay hints from nprofile identity (stage 2).
+    pub hinted_relay_urls: Vec<String>,
+    /// Bootstrap relays for CEP-17 kind 10002 discovery (stage 4).
+    pub discovery_relay_urls: Vec<String>,
+    /// Fallback relays probed in parallel with discovery (stage 4).
+    pub fallback_operational_relay_urls: Vec<String>,
+    /// Server public key for kind 10002 filter.
+    pub server_pubkey: PublicKey,
+    /// Signer for temporary relay pool connections.
+    pub signer: Arc<dyn NostrSigner>,
+    /// Timeout for discovery and fallback probing.
+    pub timeout: Duration,
+}
+
+/// Resolve operational relay URLs through a multi-stage pipeline.
+///
+/// Stages (returns on first non-empty result):
+/// 1. Configured relays (explicit `relay_urls`)
+/// 2. Hinted relays (from nprofile)
+/// 3. If no discovery relays available: use fallback or return empty
+/// 4. Race CEP-17 discovery vs fallback probing (`tokio::select!`)
+/// 5. Sequential fallback if race winner was empty
+/// 6. Last resort: use discovery relay URLs as operational
+///
+/// Mirrors the TS SDK `resolveOperationalRelays()`.
+pub async fn resolve_operational_relays(config: RelayResolutionConfig) -> Vec<String> {
+    // Stage 1: configured relays
+    if !config.configured_relay_urls.is_empty() {
+        return config.configured_relay_urls;
+    }
+
+    // Stage 2: hinted relays (from nprofile)
+    if !config.hinted_relay_urls.is_empty() {
+        tracing::info!(
+            target: LOG_TARGET,
+            relay_count = config.hinted_relay_urls.len(),
+            "Using relay hints from server identity"
+        );
+        return config.hinted_relay_urls;
+    }
+
+    // Stage 3: no discovery relays available
+    if config.discovery_relay_urls.is_empty() {
+        if !config.fallback_operational_relay_urls.is_empty() {
+            tracing::info!(
+                target: LOG_TARGET,
+                relay_count = config.fallback_operational_relay_urls.len(),
+                "Using configured fallback operational relays"
+            );
+            return config.fallback_operational_relay_urls;
+        }
+        return vec![];
+    }
+
+    // Stage 4: race discovery vs fallback
+    let discovery_urls = config.discovery_relay_urls;
+    let last_resort_urls = discovery_urls.clone();
+    let fallback_urls = config.fallback_operational_relay_urls;
+    let server_pubkey = config.server_pubkey;
+    let signer = config.signer;
+    let timeout = config.timeout;
+
+    let discovery_fut = async {
+        let entries =
+            fetch_server_relay_list(&server_pubkey, &discovery_urls, signer.clone(), timeout)
+                .await
+                .unwrap_or_default();
+        select_operational_relay_urls(&entries)
+    };
+
+    let fallback_fut = connect_fallback_operational_relays(&fallback_urls, signer.clone(), timeout);
+
+    pin!(discovery_fut);
+    pin!(fallback_fut);
+
+    // Race: first non-empty wins. If winner is empty, await the loser.
+    enum RaceWinner {
+        Discovery(Vec<String>),
+        Fallback(Vec<String>),
+    }
+
+    // When the winner is non-empty the losing future is dropped.
+    // If it was connect_fallback_operational_relays, the temporary
+    // pool disconnects when the Client drops -- resource leak is minimal.
+    let winner = tokio::select! {
+        result = &mut discovery_fut => RaceWinner::Discovery(result),
+        result = &mut fallback_fut => RaceWinner::Fallback(result),
+    };
+
+    match winner {
+        RaceWinner::Discovery(urls) if !urls.is_empty() => {
+            tracing::info!(target: LOG_TARGET, relay_count = urls.len(), "Resolved operational relays");
+            return urls;
+        }
+        RaceWinner::Fallback(urls) if !urls.is_empty() => {
+            tracing::info!(target: LOG_TARGET, relay_count = urls.len(), "Resolved operational relays");
+            return urls;
+        }
+        RaceWinner::Discovery(_) => {
+            // Discovery returned empty; await fallback
+            let fallback_result = fallback_fut.await;
+            if !fallback_result.is_empty() {
+                tracing::info!(target: LOG_TARGET, relay_count = fallback_result.len(), "Using configured fallback operational relays");
+                return fallback_result;
+            }
+        }
+        RaceWinner::Fallback(_) => {
+            // Fallback returned empty; await discovery
+            let discovery_result = discovery_fut.await;
+            if !discovery_result.is_empty() {
+                tracing::info!(target: LOG_TARGET, relay_count = discovery_result.len(), "Resolved operational relays from server relay list");
+                return discovery_result;
+            }
+        }
+    }
+
+    // Stage 6: last resort — use discovery relays as operational
+    tracing::warn!(
+        target: LOG_TARGET,
+        relay_count = last_resort_urls.len(),
+        "No operational relays discovered from kind 10002; falling back to discovery relays"
+    );
+    last_resort_urls
+}
+
+/// Probe fallback operational relays for connectivity.
+///
+/// Creates a temporary pool, attempts to connect within `timeout`.
+/// Returns the fallback URLs on success, empty vec on failure.
+/// Mirrors the TS SDK `connectFallbackOperationalRelays()`.
+pub async fn connect_fallback_operational_relays(
+    fallback_urls: &[String],
+    signer: Arc<dyn NostrSigner>,
+    timeout: Duration,
+) -> Vec<String> {
+    if fallback_urls.is_empty() {
+        return vec![];
+    }
+
+    let pool = match RelayPool::new(signer).await {
+        Ok(p) => p,
+        Err(_) => return vec![],
+    };
+
+    let connect_result = tokio::time::timeout(timeout, pool.connect(fallback_urls)).await;
+
+    let _ = pool.disconnect().await;
+
+    match connect_result {
+        Ok(Ok(())) => fallback_urls.to_vec(),
+        Ok(Err(e)) => {
+            tracing::warn!(
+                target: LOG_TARGET,
+                error = %e,
+                "Fallback operational relay connection failed"
+            );
+            vec![]
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: LOG_TARGET,
+                "Fallback operational relay probing timed out"
+            );
+            vec![]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::relay::MockRelayPool;
+
+    fn make_signer() -> Arc<dyn NostrSigner> {
+        let keys = Keys::generate();
+        Arc::new(keys) as Arc<dyn NostrSigner>
+    }
+
+    fn make_config(
+        configured: Vec<String>,
+        hinted: Vec<String>,
+        discovery: Vec<String>,
+        fallback: Vec<String>,
+    ) -> RelayResolutionConfig {
+        RelayResolutionConfig {
+            configured_relay_urls: configured,
+            hinted_relay_urls: hinted,
+            discovery_relay_urls: discovery,
+            fallback_operational_relay_urls: fallback,
+            server_pubkey: Keys::generate().public_key(),
+            signer: make_signer(),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    #[tokio::test]
+    async fn configured_relays_returned_immediately() {
+        let config = make_config(
+            vec!["wss://configured.example.com".to_string()],
+            vec!["wss://hinted.example.com".to_string()],
+            vec!["wss://discovery.example.com".to_string()],
+            vec!["wss://fallback.example.com".to_string()],
+        );
+        let result = resolve_operational_relays(config).await;
+        assert_eq!(result, vec!["wss://configured.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn hinted_relays_returned_when_no_configured() {
+        let config = make_config(
+            vec![],
+            vec!["wss://hint1.example.com".to_string()],
+            vec!["wss://discovery.example.com".to_string()],
+            vec![],
+        );
+        let result = resolve_operational_relays(config).await;
+        assert_eq!(result, vec!["wss://hint1.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn no_discovery_with_fallback_returns_fallback() {
+        let config = make_config(
+            vec![],
+            vec![],
+            vec![],
+            vec!["wss://fallback.example.com".to_string()],
+        );
+        let result = resolve_operational_relays(config).await;
+        assert_eq!(result, vec!["wss://fallback.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn no_discovery_no_fallback_returns_empty() {
+        let config = make_config(vec![], vec![], vec![], vec![]);
+        let result = resolve_operational_relays(config).await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn both_empty_falls_back_to_discovery_relays() {
+        // discovery_relay_urls are non-empty but the server has no kind 10002 event,
+        // and fallback is empty — last resort returns discovery URLs.
+        let config = make_config(
+            vec![],
+            vec![],
+            vec!["wss://bootstrap.example.com".to_string()],
+            vec![],
+        );
+        let result = resolve_operational_relays(config).await;
+        assert_eq!(result, vec!["wss://bootstrap.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn connect_fallback_empty_urls_returns_empty() {
+        let result =
+            connect_fallback_operational_relays(&[], make_signer(), Duration::from_secs(1)).await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn discovery_with_mock_returns_relay_entries() {
+        // Test the fetch path via fetch_relay_list_from_pool directly
+        use crate::core::constants::{tags, RELAY_LIST_METADATA_KIND};
+        use crate::transport::client::server_relay_discovery::fetch_relay_list_from_pool;
+
+        let pool = MockRelayPool::new();
+        let server_keys = Keys::generate();
+
+        let tags = vec![Tag::custom(
+            TagKind::Custom(tags::RELAY.into()),
+            vec!["wss://discovered.example.com"],
+        )];
+        let event = EventBuilder::new(Kind::Custom(RELAY_LIST_METADATA_KIND), "")
+            .tags(tags)
+            .custom_created_at(Timestamp::from(1000u64))
+            .sign_with_keys(&server_keys)
+            .unwrap();
+        pool.inject_event(event).await;
+
+        let entries =
+            fetch_relay_list_from_pool(&server_keys.public_key(), &pool, Duration::from_secs(5))
+                .await
+                .unwrap();
+        let urls = select_operational_relay_urls(&entries);
+        assert_eq!(urls, vec!["wss://discovered.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn marker_precedence_unmarked_preferred() {
+        use crate::core::constants::{tags, RELAY_LIST_METADATA_KIND};
+        use crate::transport::client::server_relay_discovery::fetch_relay_list_from_pool;
+
+        let pool = MockRelayPool::new();
+        let server_keys = Keys::generate();
+
+        let tags = vec![
+            Tag::custom(
+                TagKind::Custom(tags::RELAY.into()),
+                vec!["wss://unmarked.example.com"],
+            ),
+            Tag::custom(
+                TagKind::Custom(tags::RELAY.into()),
+                vec!["wss://read.example.com", "read"],
+            ),
+        ];
+        let event = EventBuilder::new(Kind::Custom(RELAY_LIST_METADATA_KIND), "")
+            .tags(tags)
+            .custom_created_at(Timestamp::from(1000u64))
+            .sign_with_keys(&server_keys)
+            .unwrap();
+        pool.inject_event(event).await;
+
+        let entries =
+            fetch_relay_list_from_pool(&server_keys.public_key(), &pool, Duration::from_secs(5))
+                .await
+                .unwrap();
+        let urls = select_operational_relay_urls(&entries);
+        assert_eq!(urls, vec!["wss://unmarked.example.com"]);
+    }
+
+    #[test]
+    fn with_discovery_relay_urls_overrides_bootstrap() {
+        use crate::transport::client::NostrClientTransportConfig;
+
+        let config = NostrClientTransportConfig::default()
+            .with_discovery_relay_urls(vec!["wss://custom-discovery.example.com".to_string()]);
+        assert_eq!(
+            config.discovery_relay_urls,
+            Some(vec!["wss://custom-discovery.example.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn with_fallback_operational_relay_urls_stored_separately() {
+        use crate::transport::client::NostrClientTransportConfig;
+
+        let config = NostrClientTransportConfig::default()
+            .with_fallback_operational_relay_urls(vec!["wss://fallback.example.com".to_string()]);
+        assert_eq!(
+            config.fallback_operational_relay_urls,
+            Some(vec!["wss://fallback.example.com".to_string()])
+        );
+        assert!(config.relay_urls.is_empty());
+    }
+}

--- a/src/transport/client/server_relay_discovery.rs
+++ b/src/transport/client/server_relay_discovery.rs
@@ -94,8 +94,7 @@ pub(crate) async fn fetch_relay_list_from_pool(
 ) -> Result<Vec<RelayListEntry>> {
     let filter = Filter::new()
         .kind(Kind::Custom(RELAY_LIST_METADATA_KIND))
-        .author(*server_pubkey)
-        .limit(1);
+        .author(*server_pubkey);
 
     let mut events = relay_pool.fetch_events(vec![filter], timeout).await?;
 

--- a/tests/e2e_happy_path.rs
+++ b/tests/e2e_happy_path.rs
@@ -184,7 +184,8 @@ async fn run_e2e_scenario(mode: EncryptionMode) {
     let client_transport = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
             .with_server_pubkey(server_pubkey_hex)
-            .with_encryption_mode(mode),
+            .with_encryption_mode(mode)
+            .with_relay_urls(vec!["wss://mock.relay".to_string()]),
         as_pool(client_pool),
     )
     .await
@@ -381,7 +382,8 @@ async fn e2e_multi_client_no_crosstalk() {
     let client1_transport = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
             .with_server_pubkey(server_pubkey_hex.clone())
-            .with_encryption_mode(EncryptionMode::Optional),
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_relay_urls(vec!["wss://mock.relay".to_string()]),
         as_pool(client1_pool),
     )
     .await
@@ -390,7 +392,8 @@ async fn e2e_multi_client_no_crosstalk() {
     let client2_transport = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
             .with_server_pubkey(server_pubkey_hex)
-            .with_encryption_mode(EncryptionMode::Optional),
+            .with_encryption_mode(EncryptionMode::Optional)
+            .with_relay_urls(vec!["wss://mock.relay".to_string()]),
         as_pool(client2_pool),
     )
     .await

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -160,6 +160,7 @@ async fn full_initialization_handshake() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -293,6 +294,7 @@ async fn encryption_mode_optional_accepts_plaintext() {
     // Client uses Disabled — sends plaintext kind 25910.
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -353,6 +355,7 @@ async fn auth_allowlist_blocks_disallowed_pubkey() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -403,6 +406,7 @@ async fn encryption_mode_required_drops_plaintext() {
     // Client sends plaintext (Disabled mode).
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -446,6 +450,7 @@ async fn encrypted_gift_wrap_roundtrip() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
@@ -529,6 +534,7 @@ async fn gift_wrap_dedup_skips_duplicate_delivery() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
@@ -598,6 +604,7 @@ async fn correlated_notification_has_e_tag() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -692,6 +699,7 @@ async fn encryption_required_client_optional_server() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
@@ -749,6 +757,7 @@ async fn encryption_optional_both_sides_encrypted_path() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Optional),
         as_pool(client_pool),
@@ -952,6 +961,7 @@ async fn broadcast_notification_reaches_initialized_client() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pk.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(c1_pool),
@@ -1064,6 +1074,7 @@ async fn uncorrelated_notification_passes_through() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -1157,6 +1168,7 @@ async fn correlated_notification_unknown_e_tag_is_dropped() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -1254,6 +1266,7 @@ async fn auth_allowed_pubkey_receives_response() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -1333,6 +1346,7 @@ async fn excluded_capability_bypasses_auth() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -1602,6 +1616,7 @@ async fn encryption_disabled_server_rejects_gift_wrap() {
     // Client requires encryption — sends gift-wrap (kind 1059).
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Required),
         as_pool(client_pool),
@@ -1824,6 +1839,7 @@ async fn send_response_is_one_shot_under_concurrency() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -1921,6 +1937,7 @@ async fn send_response_publish_failure_allows_one_successful_retry() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2046,6 +2063,7 @@ async fn announced_server_sends_unauthorized_error_response() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2121,6 +2139,7 @@ async fn private_server_silently_drops_unauthorized_request() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2182,6 +2201,7 @@ async fn announced_server_does_not_error_on_unauthorized_notification() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2239,6 +2259,7 @@ async fn first_response_includes_discovery_tags() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2361,6 +2382,7 @@ async fn notification_mirror_selection_wrt_cep_19() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Optional)
             .with_gift_wrap_mode(GiftWrapMode::Ephemeral),
@@ -2446,6 +2468,7 @@ async fn server_response_includes_encryption_tags_when_enabled() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2520,6 +2543,7 @@ async fn server_response_excludes_ephemeral_tag_when_persistent() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2591,6 +2615,7 @@ async fn server_learns_capabilities_from_client_request() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2653,6 +2678,7 @@ async fn server_disabled_encryption_omits_encryption_tags() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2722,6 +2748,7 @@ async fn client_disabled_encryption_emits_no_discovery_tags() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_keys.public_key().to_hex())
             .with_encryption_mode(EncryptionMode::Disabled)
             .with_gift_wrap_mode(GiftWrapMode::Optional),
@@ -2769,6 +2796,7 @@ async fn client_second_request_carries_no_discovery_tags() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_keys.public_key().to_hex())
             .with_encryption_mode(EncryptionMode::Disabled)
             .with_gift_wrap_mode(GiftWrapMode::Optional),
@@ -2837,6 +2865,7 @@ async fn client_learns_server_capabilities_from_first_response() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),
@@ -2922,6 +2951,7 @@ async fn client_or_assigns_capabilities_across_responses() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&client_pool) as Arc<dyn RelayPoolTrait>,
@@ -3034,6 +3064,7 @@ async fn client_baseline_event_not_replaced_by_later_responses() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         Arc::clone(&client_pool) as Arc<dyn RelayPoolTrait>,
@@ -3127,6 +3158,7 @@ async fn client_optional_encryption_emits_discovery_tags() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Optional)
             .with_gift_wrap_mode(GiftWrapMode::Optional),
@@ -3197,6 +3229,7 @@ async fn multi_client_concurrent_requests_both_get_responses() {
 
     let mut client_a = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_a_pool),
@@ -3206,6 +3239,7 @@ async fn multi_client_concurrent_requests_both_get_responses() {
 
     let mut client_b = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_b_pool),
@@ -3354,6 +3388,7 @@ async fn client_close_stops_event_loop() {
 
     let mut client = NostrClientTransport::with_relay_pool(
         NostrClientTransportConfig::default()
+            .with_relay_urls(vec!["wss://mock.relay".to_string()])
             .with_server_pubkey(server_pubkey.to_hex())
             .with_encryption_mode(EncryptionMode::Disabled),
         as_pool(client_pool),


### PR DESCRIPTION
Closes #80 (CEP-17 implementation). 

Wires everything from PR #82  into the client transport.

What's new:

6-stage relay resolution - clients no longer need hardcoded relay URLs. resolve_operational_relays() tries in order: configured relays, nprofile hints, no-discovery fallback, race discovery vs fallback via tokio::select!, sequential completion, last resort. Matches the TS SDK resolution chain exactly.

Config additions - discovery_relay_urls (defaults to bootstrap relays) and fallback_operational_relay_urls. Both optional with builder methods.

Transport wiring - relay resolution now runs in start() before connect(). Default relay_urls changed from "wss://relay.damus.io" to vec![] since clients should rely on resolution instead of a hardcoded relay.

Existing tests updated to pass relay_urls explicitly so they bypass resolution and connect directly as before.

10 new tests covering all resolution stages.