### PR TITLE
fix: make oversized e2e test deterministic and hermetic relay config

### DIFF
--- a/tests/oversized_timeout_e2e.rs
+++ b/tests/oversized_timeout_e2e.rs
@@ -778,7 +778,13 @@ async fn watchdog_reaps_stalled_inbound_transfer_server() {
 /// Timing: 150 ms publish delay vs 400 ms idle (≥ 2.5×); ~240 KB payload = ≥ 5
 /// chunks at the 48 000 B default chunk size, pinned above the 65 535 B
 /// single-event NIP-44 cap so an unfragmented path cannot pass.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+///
+/// Runs on **paused virtual time** so the publish/idle relationship is exact
+/// (each 150 ms publish always fires before the 400 ms idle timer) and the test
+/// is deterministic regardless of host speed or CPU contention. The sibling
+/// `oversized_trickle_trips_max_total_timeout` proves the same machinery under
+/// paused time; this is the success-path counterpart.
+#[tokio::test(start_paused = true)]
 async fn oversized_response_progress_resets_idle_timeout() {
     let (client_pool, server_pool) = MockRelayPool::create_pair();
     let server_pubkey = server_pool.mock_public_key();

--- a/tests/transport_integration.rs
+++ b/tests/transport_integration.rs
@@ -1667,6 +1667,7 @@ async fn response_mirrors_client_encryption_format() {
 
         let mut client = NostrClientTransport::with_relay_pool(
             NostrClientTransportConfig::default()
+                .with_relay_urls(vec!["wss://mock.relay".to_string()])
                 .with_server_pubkey(server_pubkey.to_hex())
                 .with_encryption_mode(EncryptionMode::Disabled),
             as_pool(client_pool),
@@ -1749,6 +1750,7 @@ async fn response_mirrors_client_encryption_format() {
 
         let mut client = NostrClientTransport::with_relay_pool(
             NostrClientTransportConfig::default()
+                .with_relay_urls(vec!["wss://mock.relay".to_string()])
                 .with_server_pubkey(server_pubkey.to_hex())
                 .with_encryption_mode(EncryptionMode::Required),
             as_pool(client_pool),


### PR DESCRIPTION
Fix flaky e2e test and non-hermetic relay config in CI.

Converts `oversized_response_progress_resets_idle_timeout` to virtual time (start_paused) and adds explicit mock relay URLs to skip real network discovery in `response_mirrors_client_encryption_format`.