### PR TITLE
chore: bump version to 0.2.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.2.0] - Unreleased
+
+### Added
+
+- CEP-22: oversized payload transfer for chunking MCP messages that exceed the NIP-44 single-event size limit (~65 KB), using a transport-agnostic framing engine (start/accept/chunk/end/abort frames, SHA-256 digest verification, and out-of-order reassembly), enabled by default and negotiated through the `support_oversized_transfer` capability tag so servers only fragment to clients that advertise support (#88, #89, #91)
+- CEP-22: progress-aware request timeouts and an in-flight transfer watchdog, providing per-chunk idle-timeout reset, a max-total transfer cap, and receiver-side reaping of stalled transfers, opt-in via `call_tool_with_options` and `progress_aware_options` (#92)
+- CEP-17: multi-stage relay resolution with server identity parsing, relay list (NIP-65) fetching, and `fetch_events`, plus transport integration that resolves a server's preferred relays before connecting (#82, #83)
+- CEP-6: expanded server announcements with full `InitializeResult` parsing in `ServerAnnouncement`, auto-publishing on `start()`, relay list publishing, and a tool and resource schema mapping table (#77, #78, #79, #81)
+- CEP-23: optional server profile metadata published as a NIP-01 kind 0 event, via a new `ProfileMetadata` type, so clients see a human-friendly identity (#77, #79)
+- CI: MSRV and feature-matrix checks (#75)
+
+### Changed
+
+- Upgraded `rmcp` from 0.16.0 to 1.7.x to gain progress-aware request timeouts (#86)
+- Raised the minimum supported Rust version (MSRV) from 1.70 to 1.88
+- Added `sha2` and `hex` dependencies for CEP-22 payload digests
+- Enabled the `missing_docs` lint, closed rustdoc coverage gaps, and added SDK documentation links and a CEP-22 oversized-transfer guide (#67, #73)
+
+### Fixed
+
+- `MockRelayPool` live broadcast now respects per-subscription filters instead of echoing every event to every subscriber (#90)
+- Made the oversized-transfer e2e timing tests deterministic with virtual paused time and the relay config hermetic, removing CI flakiness and a 30 s real-network discovery hang (#93, #94)
+
 ## [0.1.1] - 2026-05-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextvm-sdk"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Rust SDK for the ContextVM protocol — MCP over Nostr"

--- a/README.md
+++ b/README.md
@@ -168,13 +168,16 @@ async fn main() -> contextvm_sdk::Result<()> {
 
 The in-repo Rust SDK guides live in [`docs/README.md`](docs/README.md):
 
-- For most users, the main pattern is: build an `rmcp` server or client, then attach [`NostrServerTransport`](src/transport/server/mod.rs:87) or [`NostrClientTransport`](src/transport/client/mod.rs:69).
+- For most users, the main pattern is: build an `rmcp` server or client, then attach [`NostrServerTransport`](src/transport/server/mod.rs:135) or [`NostrClientTransport`](src/transport/client/mod.rs:143).
 
 - [`docs/overview.md`](docs/overview.md)
 - [`docs/server-transport.md`](docs/server-transport.md)
 - [`docs/client-transport.md`](docs/client-transport.md)
 - [`docs/discovery.md`](docs/discovery.md)
 - [`docs/encryption.md`](docs/encryption.md)
+- [`docs/transport-modes.md`](docs/transport-modes.md)
+- [`docs/stateless.md`](docs/stateless.md)
+- [`docs/oversized-transfer.md`](docs/oversized-transfer.md)
 - [`docs/rmcp.md`](docs/rmcp.md)
 - [`docs/transports.md`](docs/transports.md)
 - [`docs/gateway.md`](docs/gateway.md)
@@ -218,6 +221,7 @@ model and tuning.
 |--------------------------|-----------------------|------------------------------------------|
 | `relay_urls`             | `["wss://relay.damus.io"]` | Nostr relays to connect to          |
 | `encryption_mode`        | `Optional`            | Encryption policy                        |
+| `gift_wrap_mode`         | `Optional`            | Gift-wrap policy (CEP-19): persistent (1059) vs ephemeral (21059) |
 | `server_info`            | `None`                | Server metadata for announcements        |
 | `is_announced_server`    | `false`               | Auto-publish announcements on start (CEP-6) |
 | `allowed_public_keys`    | `[]` (allow all)      | Client pubkey allowlist (hex)            |
@@ -236,6 +240,7 @@ model and tuning.
 | `relay_urls`                       | `[]`                       | Nostr relays to connect to (empty = use relay resolution) |
 | `server_pubkey`                    | (required)                 | Target server's public key (hex, npub, or nprofile) |
 | `encryption_mode`                  | `Optional`                 | Encryption policy                    |
+| `gift_wrap_mode`                   | `Optional`                 | Gift-wrap policy (CEP-19): persistent (1059) vs ephemeral (21059) |
 | `is_stateless`                     | `false`                    | Emulate initialize locally           |
 | `timeout`                          | `30s`                      | Response timeout                     |
 | `discovery_relay_urls`             | `None` (bootstrap relays)  | Relays for CEP-17 kind 10002 discovery |

--- a/docs/client-transport.md
+++ b/docs/client-transport.md
@@ -99,15 +99,14 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let result = client
-        .call_tool(CallToolRequestParams {
-            name: "echo".into(),
-            arguments: serde_json::from_value(serde_json::json!({
-                "message": "hello from native contextvm client"
-            }))
-            .ok(),
-            meta: None,
-            task: None,
-        })
+        .call_tool(
+            CallToolRequestParams::new("echo").with_arguments(
+                serde_json::from_value(serde_json::json!({
+                    "message": "hello from native contextvm client"
+                }))
+                .unwrap(),
+            ),
+        )
         .await?;
 
     println!("Echo result: {}", first_text(&result));
@@ -168,4 +167,4 @@ Use the proxy guide when you want a simpler message-oriented bridge and do not w
 - The initialize request is sent automatically as part of the running client startup sequence.
 - Stateless initialization behavior is covered by the conformance tests.
 - Capability learning and gift-wrap handling happen inside the client transport implementation.
-- When `relay_urls` is empty, `start()` runs 6-stage relay resolution before connecting: configured relays > nprofile hints > CEP-17 kind 10002 discovery > fallback probing > bootstrap defaults. Callers can set `server_pubkey` to an nprofile and omit `relay_urls` entirely.
+- When `relay_urls` is empty, `start()` runs 6-stage relay resolution before connecting: configured relays > nprofile hints > CEP-17 kind 10002 discovery > fallback probing > sequential fallback > bootstrap defaults. Callers can set `server_pubkey` to an nprofile and omit `relay_urls` entirely.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -52,6 +52,9 @@ ContextVM keeps MCP semantics intact and uses Nostr only as the transport envelo
 - direct plaintext ContextVM traffic uses kind `25910`
 - encrypted traffic uses gift-wrap kinds `1059` or `21059`
 - public discovery uses kinds `11316` through `11320`
+- server relay lists are published as NIP-65 kind `10002` events (CEP-17)
+- optional server profile metadata is published as a NIP-01 kind `0` event (CEP-23)
+- oversized MCP messages that exceed the single-event size limit are fragmented across `notifications/progress` frames and transparently reassembled (CEP-22)
 - routing is done with `p` tags and request/response correlation with `e` tags, as reflected in the repository root README
 
 ## Core types you should know
@@ -59,6 +62,7 @@ ContextVM keeps MCP semantics intact and uses Nostr only as the transport envelo
 - `EncryptionMode`: `Optional`, `Required`, `Disabled`
 - `GiftWrapMode`: `Optional`, `Ephemeral`, `Persistent`
 - `contextvm_sdk::ServerInfo`: announcement metadata
+- `contextvm_sdk::ProfileMetadata`: optional NIP-01 kind `0` profile metadata for a human-friendly server identity (CEP-23)
 - `CapabilityExclusion`: allowlist bypass rules for specific methods or capabilities
 
 ## Typical workflows

--- a/docs/server-transport.md
+++ b/docs/server-transport.md
@@ -175,4 +175,5 @@ Use the gateway guide when you already have a request loop or existing local MCP
 - `rmcp` accepts pre-init ping and enters the main loop immediately after initialization completes.
 - ContextVM response routing depends on request event ids.
 - Encryption mirroring and announcement behavior are covered by the integration tests.
-- When `is_announced_server` is `true`, the transport auto-publishes all announcement events on `start()` via synthetic MCP requests: kind 11316 (server announcement), kinds 11317-11320 (tools, resources, templates, prompts), kind 10002 (relay list), and kind 0 (profile metadata if configured).
+- Announcement publishing is started by the rmcp worker just after `start()` (not by `transport.start()` itself, because it injects synthetic MCP requests that need an rmcp handler to answer). When `is_announced_server` is `true`, the transport publishes the gated announcement events via those synthetic requests: kind 11316 (server announcement) and kinds 11317-11320 (tools, resources, templates, prompts).
+- Independently of `is_announced_server`, it also publishes kind 10002 (relay list, when `publish_relay_list` is true (the default) and the advertised relay URLs are non-empty) and kind 0 (profile metadata, when `profile_metadata` is configured).


### PR DESCRIPTION
Prepares rs-sdk for the 0.2.0 release.

- Version bumped 0.1.1 → 0.2.0 in Cargo.toml
- CHANGELOG.md updated with the 0.2.0 Unreleased entry covering CEP-22, CEP-17, CEP-6, CEP-23, rmcp upgrade, and MSRV bump
- Doc fixes: stale source-line anchors, incorrect kind-gating claim in server-transport.md, non-compiling call_tool 
example, overview.md updated for 0.2 features, guide list and config tables completed in README

Publish is blocked on Phase 2 - the rmcp git dep must be swapped for the official crates.io version (rmcp v1.8.0, pending release) before cargo publish.